### PR TITLE
Added BraneScript attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to the Brane framework will be documented in this file.
 
-## [3.1.0] - TODO
+## [4.0.0] - TODO
 ### Added
+- Attributes to BraneScript (e.g., `#[tag("amy.foo")]` or `#![on("foo")]`).
 - The `branectl wizard` subcommand, which interactively goes through the steps of setting up a node.
 - Commands for cross-compiling to macOS x86-64 _and_ ARM 64-bit from Linux :)
 - `branec --trace` flag to enable trace-level debugging.
@@ -19,6 +20,7 @@ All notable changes to the Brane framework will be documented in this file.
   - To do this, the interface between the driver and planner have been updated (not a breaking change since inter-service communication with different service versions is not assumed).
 - `branec` now uses [humanlog](https://github.com/Lut99/humanlog-rs) as logging backend for nicer messages.
 - `brane-drv` and `brane-plr` are now using Rust 2021 instead of Rust 2018.
+- BraneScript syntax to remove the `on`-structs, and instead using `on`-, `loc`- or `location`-attributes \[**breaking change**\].
 
 ### Fixed
 - The BraneScript compiler hanging in an infinite loop in some cases.

--- a/brane-ast/src/ast.rs
+++ b/brane-ast/src/ast.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    30 Aug 2022, 11:55:49
 //  Last edited:
-//    07 Nov 2023, 14:40:27
+//    08 Dec 2023, 18:07:40
 //  Auto updated?
 //    Yes
 //
@@ -49,7 +49,9 @@ lazy_static!(
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Workflow {
     /// The global symbol / definition table. This specific table is also affectionally referred to as the "Workflow table".
-    pub table: Arc<SymTable>,
+    pub table:    Arc<SymTable>,
+    /// Toplevel metadata
+    pub metadata: Arc<HashSet<Metadata>>,
 
     /// Implements the graph. Note that the ordering of this graph is important, but it will not be executed linearly.
     pub graph: Arc<Vec<Edge>>,
@@ -70,7 +72,8 @@ impl Workflow {
     #[inline]
     pub fn new(table: SymTable, graph: Vec<Edge>, funcs: HashMap<usize, Vec<Edge>>) -> Self {
         Self {
-            table: Arc::new(table),
+            table:    Arc::new(table),
+            metadata: Arc::new(HashSet::new()),
 
             graph: Arc::new(graph),
             funcs: Arc::new(funcs),
@@ -116,12 +119,28 @@ impl Default for Workflow {
     #[inline]
     fn default() -> Self {
         Self {
-            table: Arc::new(SymTable::new()),
+            table:    Arc::new(SymTable::new()),
+            metadata: Arc::new(HashSet::new()),
 
             graph: Arc::new(vec![]),
             funcs: Arc::new(HashMap::new()),
         }
     }
+}
+
+
+
+/// Defines a piece of metadata.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Metadata {
+    /// The tag that is attached.
+    pub tag: String,
+    /// Some signature verifying this metadata.
+    pub signature: String,
+}
+impl PartialEq for Metadata {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool { self.tag == other.tag }
 }
 
 

--- a/brane-ast/src/ast_unresolved.rs
+++ b/brane-ast/src/ast_unresolved.rs
@@ -1,20 +1,22 @@
 //  AST UNRESOLVED.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    03 Sep 2022, 12:31:20
 //  Last edited:
-//    15 Sep 2022, 13:45:21
+//    12 Dec 2023, 15:10:22
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Contains special patches / overwrites for the normal `brane-ast` AST
 //!   that make compilation life a super-duper amount easier.
-// 
+//
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
+use crate::ast::Metadata;
 use crate::edgebuffer::EdgeBuffer;
 
 
@@ -24,25 +26,24 @@ use crate::edgebuffer::EdgeBuffer;
 pub struct UnresolvedWorkflow {
     // Note that the workflow table is actually represented in the state itself.
     /// The main buffer to start executing, which references all other buffers.
-    pub main_edges : EdgeBuffer,
+    pub main_edges: EdgeBuffer,
     /// The list of EdgeBuffers that implement functions. Every buffer is mapped by the function's ID in the workflow table.
-    pub f_edges    : HashMap<usize, EdgeBuffer>,
+    pub f_edges:    HashMap<usize, EdgeBuffer>,
+    /// Toplevel metadata
+    pub metadata:   Arc<HashSet<Metadata>>,
 }
 
 impl UnresolvedWorkflow {
     /// Constructor for the Workflow that initializes it to values that have already been computed.
-    /// 
+    ///
     /// # Arguments
     /// - `main_edges`: The main buffer containing toplevel code.
     /// - `f_edges`: The buffers that detail the code per-function.
-    /// 
+    ///
     /// # Returns
     /// A new Workflow instance.
     #[inline]
     pub fn new(main_edges: EdgeBuffer, f_edges: HashMap<usize, EdgeBuffer>) -> Self {
-        Self {
-            main_edges,
-            f_edges,
-        }
+        Self { main_edges, f_edges, metadata: Arc::new(HashSet::new()) }
     }
 }

--- a/brane-ast/src/compile.rs
+++ b/brane-ast/src/compile.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    12 Sep 2022, 18:12:44
 //  Last edited:
-//    08 Dec 2023, 10:29:51
+//    08 Dec 2023, 16:39:03
 //  Auto updated?
 //    Yes
 //
@@ -36,7 +36,7 @@ pub enum CompileStage {
     /// References nb compile stage.
     None  = 0,
     /// References the last compile stage, i.e., all stages.
-    All   = 13,
+    All   = 14,
 
     // Individual stages
     /// The initial stage where we process attribute statements.
@@ -51,18 +51,20 @@ pub enum CompileStage {
     Data  = 5,
     /// The sixth stage where we resolve on-structs.
     Location = 6,
-    /// The seventh stage where we apply various optimizations, e.g., constant unfolding, constant casting, function inlining, etc.
-    Optimization = 7,
-    /// The eighth stage where we prune the resulting tree to make compilation easier (without affecting functionality).
-    Prune = 8,
-    /// The ninth stage is the really final pre-compile stage, where we already collect definitions into a flattened symbol table tree structure.
-    Flatten = 9,
-    /// The tenth stage where we compile the Program to a Workflow.
-    Compile = 10,
-    /// The eventh stage where we optimize the resulting workflow some more.
-    WorkflowOptimization = 11,
-    /// The twelth and final stage where we resolve the 'next' fields in the UnresolvedWorkflow so it becomes a Workflow.
-    WorkflowResolve = 12,
+    /// The seventh stage where we add user-supplied metadata to a workflow.
+    Metadata = 7,
+    /// The eighth stage where we apply various optimizations, e.g., constant unfolding, constant casting, function inlining, etc.
+    Optimization = 8,
+    /// The ninth stage where we prune the resulting tree to make compilation easier (without affecting functionality).
+    Prune = 9,
+    /// The tenth stage is the really final pre-compile stage, where we already collect definitions into a flattened symbol table tree structure.
+    Flatten = 10,
+    /// The eleventh stage where we compile the Program to a Workflow.
+    Compile = 11,
+    /// The twelth stage where we optimize the resulting workflow some more.
+    WorkflowOptimization = 12,
+    /// The thirtheenth and final stage where we resolve the 'next' fields in the UnresolvedWorkflow so it becomes a Workflow.
+    WorkflowResolve = 13,
 }
 
 
@@ -363,6 +365,15 @@ pub fn compile_snippet_to<R: std::io::Read>(
     if stage >= CompileStage::Location {
         trace!("Running traversal: location");
         program = match traversals::location::do_traversal(program) {
+            Ok(program) => program,
+            Err(errs) => {
+                return CompileResult::Err(errs);
+            },
+        };
+    }
+    if stage >= CompileStage::Metadata {
+        trace!("Running traversal: metadata");
+        program = match traversals::metadata::do_traversal(program, &mut warnings) {
             Ok(program) => program,
             Err(errs) => {
                 return CompileResult::Err(errs);

--- a/brane-ast/src/compile.rs
+++ b/brane-ast/src/compile.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    12 Sep 2022, 18:12:44
 //  Last edited:
-//    31 Oct 2023, 10:27:44
+//    08 Dec 2023, 10:29:51
 //  Auto updated?
 //    Yes
 //
@@ -36,31 +36,33 @@ pub enum CompileStage {
     /// References nb compile stage.
     None  = 0,
     /// References the last compile stage, i.e., all stages.
-    All   = 12,
+    All   = 13,
 
     // Individual stages
-    /// The initial stage where we resolve the symbol tables.
-    Resolve = 1,
-    /// The second stage where we resolve types (as much as possible).
-    Typing = 2,
-    /// The second stage where we null-types.
-    Null  = 3,
-    /// The fourth stage where we analyse data dependencies.
-    Data  = 4,
-    /// The fifth stage where we resolve on-structs.
-    Location = 5,
-    /// The sixth stage where we apply various optimizations, e.g., constant unfolding, constant casting, function inlining, etc.
-    Optimization = 6,
-    /// The seventh stage where we prune the resulting tree to make compilation easier (without affecting functionality).
-    Prune = 7,
-    /// The eigth stage is the really final pre-compile stage, where we already collect definitions into a flattened symbol table tree structure.
-    Flatten = 8,
-    /// The ninth stage where we compile the Program to a Workflow.
-    Compile = 9,
-    /// The tenth stage where we optimize the resulting workflow some more.
-    WorkflowOptimization = 10,
-    /// The eleventh and final stage where we resolve the 'next' fields in the UnresolvedWorkflow so it becomes a Workflow.
-    WorkflowResolve = 11,
+    /// The initial stage where we process attribute statements.
+    Attributes = 1,
+    /// The second stage where we resolve the symbol tables.
+    Resolve = 2,
+    /// The third stage where we resolve types (as much as possible).
+    Typing = 3,
+    /// The fourth stage where we null-types.
+    Null  = 4,
+    /// The figth stage where we analyse data dependencies.
+    Data  = 5,
+    /// The sixth stage where we resolve on-structs.
+    Location = 6,
+    /// The seventh stage where we apply various optimizations, e.g., constant unfolding, constant casting, function inlining, etc.
+    Optimization = 7,
+    /// The eighth stage where we prune the resulting tree to make compilation easier (without affecting functionality).
+    Prune = 8,
+    /// The ninth stage is the really final pre-compile stage, where we already collect definitions into a flattened symbol table tree structure.
+    Flatten = 9,
+    /// The tenth stage where we compile the Program to a Workflow.
+    Compile = 10,
+    /// The eventh stage where we optimize the resulting workflow some more.
+    WorkflowOptimization = 11,
+    /// The twelth and final stage where we resolve the 'next' fields in the UnresolvedWorkflow so it becomes a Workflow.
+    WorkflowResolve = 12,
 }
 
 
@@ -312,7 +314,16 @@ pub fn compile_snippet_to<R: std::io::Read>(
     };
 
     // Run the various traversals
-    // First up: program analysis (resolving symbol tables, type analysis, location analysis)
+    // First up: program analysis (attribute processing, resolving symbol tables, type analysis, location analysis)
+    if stage >= CompileStage::Attributes {
+        trace!("Running traversal: attributes");
+        program = match traversals::attributes::do_traversal(program, &mut warnings) {
+            Ok(program) => program,
+            Err(errs) => {
+                return CompileResult::Err(errs);
+            },
+        };
+    }
     if stage >= CompileStage::Resolve {
         trace!("Running traversal: resolve");
         program = match traversals::resolve::do_traversal(state, package_index, data_index, program) {

--- a/brane-ast/src/compile.rs
+++ b/brane-ast/src/compile.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    12 Sep 2022, 18:12:44
 //  Last edited:
-//    08 Dec 2023, 16:39:03
+//    12 Dec 2023, 17:21:15
 //  Auto updated?
 //    Yes
 //
@@ -36,35 +36,37 @@ pub enum CompileStage {
     /// References nb compile stage.
     None  = 0,
     /// References the last compile stage, i.e., all stages.
-    All   = 14,
+    All   = 15,
 
     // Individual stages
-    /// The initial stage where we process attribute statements.
-    Attributes = 1,
-    /// The second stage where we resolve the symbol tables.
-    Resolve = 2,
-    /// The third stage where we resolve types (as much as possible).
-    Typing = 3,
-    /// The fourth stage where we null-types.
-    Null  = 4,
-    /// The figth stage where we analyse data dependencies.
-    Data  = 5,
-    /// The sixth stage where we resolve on-structs.
-    Location = 6,
-    /// The seventh stage where we add user-supplied metadata to a workflow.
-    Metadata = 7,
-    /// The eighth stage where we apply various optimizations, e.g., constant unfolding, constant casting, function inlining, etc.
-    Optimization = 8,
-    /// The ninth stage where we prune the resulting tree to make compilation easier (without affecting functionality).
-    Prune = 9,
-    /// The tenth stage is the really final pre-compile stage, where we already collect definitions into a flattened symbol table tree structure.
-    Flatten = 10,
-    /// The eleventh stage where we compile the Program to a Workflow.
-    Compile = 11,
-    /// The twelth stage where we optimize the resulting workflow some more.
-    WorkflowOptimization = 12,
-    /// The thirtheenth and final stage where we resolve the 'next' fields in the UnresolvedWorkflow so it becomes a Workflow.
-    WorkflowResolve = 13,
+    /// The initial stage where we update AST TextRanges.
+    Offset = 1,
+    /// The second stage where we process attribute statements.
+    Attributes = 2,
+    /// The third stage where we resolve the symbol tables.
+    Resolve = 3,
+    /// The fourth stage where we resolve types (as much as possible).
+    Typing = 4,
+    /// The fifth stage where we null-types.
+    Null  = 5,
+    /// The sixth stage where we analyse data dependencies.
+    Data  = 6,
+    /// The seventh stage where we resolve on-structs.
+    Location = 7,
+    /// The eighth stage where we add user-supplied metadata to a workflow.
+    Metadata = 8,
+    /// The ninth stage where we apply various optimizations, e.g., constant unfolding, constant casting, function inlining, etc.
+    Optimization = 9,
+    /// The tenth stage where we prune the resulting tree to make compilation easier (without affecting functionality).
+    Prune = 10,
+    /// The eleventh stage is the really final pre-compile stage, where we already collect definitions into a flattened symbol table tree structure.
+    Flatten = 11,
+    /// The twelth stage where we compile the Program to a Workflow.
+    Compile = 12,
+    /// The thirtheenth stage where we optimize the resulting workflow some more.
+    WorkflowOptimization = 13,
+    /// The fourteenth and final stage where we resolve the 'next' fields in the UnresolvedWorkflow so it becomes a Workflow.
+    WorkflowResolve = 14,
 }
 
 
@@ -316,7 +318,18 @@ pub fn compile_snippet_to<R: std::io::Read>(
     };
 
     // Run the various traversals
-    // First up: program analysis (attribute processing, resolving symbol tables, type analysis, location analysis)
+    // First up: preprocessing (offset updating)
+    if stage >= CompileStage::Offset {
+        trace!("Running traversal: offset");
+        program = match traversals::offset::do_traversal(program, &state) {
+            Ok(program) => program,
+            Err(errs) => {
+                return CompileResult::Err(errs);
+            },
+        };
+    }
+
+    // Program analysis (attribute processing, resolving symbol tables, type analysis, location analysis)
     if stage >= CompileStage::Attributes {
         trace!("Running traversal: attributes");
         program = match traversals::attributes::do_traversal(program, &mut warnings) {

--- a/brane-ast/src/errors.rs
+++ b/brane-ast/src/errors.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    10 Aug 2022, 13:52:37
 //  Last edited:
-//    08 Dec 2023, 16:33:22
+//    12 Dec 2023, 16:24:48
 //  Auto updated?
 //    Yes
 //

--- a/brane-ast/src/errors.rs
+++ b/brane-ast/src/errors.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    10 Aug 2022, 13:52:37
 //  Last edited:
-//    01 Nov 2023, 16:35:43
+//    08 Dec 2023, 16:33:22
 //  Auto updated?
 //    Yes
 //
@@ -971,7 +971,7 @@ impl Display for LocationError {
         use LocationError::*;
         match self {
             IllegalLocation { .. } => write!(f, "On-structures can only accept string literals as location specifiers."),
-            OnNoLocation { .. } => write!(f, "Combination of On-structures already over-restrict locations (no location left to run any calls)."),
+            OnNoLocation { .. } => write!(f, "Combination of attributes already over-restrict locations (no location left to run any calls)."),
 
             NoLocation { .. } => write!(f, "External function call is over-restricted and has no locations left to run."),
         }

--- a/brane-ast/src/state.rs
+++ b/brane-ast/src/state.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    16 Sep 2022, 08:22:47
 //  Last edited:
-//    07 Nov 2023, 17:14:49
+//    12 Dec 2023, 15:57:52
 //  Auto updated?
 //    Yes
 //

--- a/brane-ast/src/traversals/attributes.rs
+++ b/brane-ast/src/traversals/attributes.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    08 Dec 2023, 11:35:48
 //  Last edited:
-//    08 Dec 2023, 16:30:58
+//    08 Dec 2023, 17:07:47
 //  Auto updated?
 //    Yes
 //
@@ -126,28 +126,28 @@ fn pass_stmt(stmt: &mut Stmt, parent_attrs: &mut Vec<Attribute>, mut prev_attrs:
     // Match on the statement
     use Stmt::*;
     match stmt {
-        Stmt::Attribute(attr) => {
+        Attribute(attr) => {
             // Add the attributes as next one
             prev_attrs.push(attr.clone());
             prev_attrs
         },
-        Stmt::AttributeInner(attr) => {
+        AttributeInner(attr) => {
             // Add the attributes to the parent
             parent_attrs.push(attr.clone());
             vec![]
         },
 
-        Stmt::Block { block } => {
+        Block { block } => {
             pass_block(block, prev_attrs, warns);
             vec![]
         },
 
-        Stmt::Import { name: _, version: _, st_funcs: _, st_classes: _, attrs, range: _ } => {
+        Import { name: _, version: _, st_funcs: _, st_classes: _, attrs, range: _ } => {
             // Set the previous attributes
             attrs.extend(prev_attrs);
             vec![]
         },
-        Stmt::FuncDef { ident: _, params: _, code, st_entry: _, attrs, range: _ } => {
+        FuncDef { ident: _, params: _, code, st_entry: _, attrs, range: _ } => {
             // Set the previous attributes
             attrs.extend(prev_attrs.clone());
 
@@ -155,7 +155,7 @@ fn pass_stmt(stmt: &mut Stmt, parent_attrs: &mut Vec<Attribute>, mut prev_attrs:
             pass_block(code, prev_attrs, warns);
             vec![]
         },
-        Stmt::ClassDef { ident: _, props: _, methods, st_entry: _, symbol_table: _, attrs, range: _ } => {
+        ClassDef { ident: _, props: _, methods, st_entry: _, symbol_table: _, attrs, range: _ } => {
             // Set the previous attributes
             attrs.extend(prev_attrs.clone());
 
@@ -231,7 +231,7 @@ fn pass_stmt(stmt: &mut Stmt, parent_attrs: &mut Vec<Attribute>, mut prev_attrs:
 /// The same nodes as went in, but now with annotation statements translated to annotations on structs.
 ///
 /// # Errors
-/// This pass may throw multiple `AstError::NullError`s if the user made mistakes with their variable references.
+/// This pass may throw multiple `AstError::AttributesError`s if the user made mistakes with their variable references.
 pub fn do_traversal(mut root: Program, warnings: &mut Vec<AstWarning>) -> Result<Program, Vec<AstError>> {
     // Traverse the tree, doin' all the work
     let mut warns: Vec<Warning> = vec![];

--- a/brane-ast/src/traversals/attributes.rs
+++ b/brane-ast/src/traversals/attributes.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    08 Dec 2023, 11:35:48
 //  Last edited:
-//    08 Dec 2023, 15:32:44
+//    08 Dec 2023, 16:30:58
 //  Auto updated?
 //    Yes
 //

--- a/brane-ast/src/traversals/attributes.rs
+++ b/brane-ast/src/traversals/attributes.rs
@@ -1,0 +1,245 @@
+//  ATTRIBUTES.rs
+//    by Lut99
+//
+//  Created:
+//    08 Dec 2023, 11:35:48
+//  Last edited:
+//    08 Dec 2023, 15:32:44
+//  Auto updated?
+//    Yes
+//
+//  Description:
+//!   Implements a traversal that processes [`Stmt::Attribute`]s and
+//!   [`Stmt::AttributeInner`]s into attribute annotations on other
+//!   statement nodes.
+//
+
+use brane_dsl::ast::{Attribute, Block, Node as _, Program, Stmt};
+
+use crate::errors::AstError;
+use crate::warnings::AstWarning;
+pub use crate::warnings::AttributesWarning as Warning;
+
+
+/***** TESTS *****/
+#[cfg(test)]
+mod tests {
+    use brane_dsl::ParserOptions;
+    use brane_shr::utilities::{create_data_index, create_package_index, test_on_dsl_files};
+    use specifications::data::DataIndex;
+    use specifications::package::PackageIndex;
+
+    use super::super::print::dsl;
+    use super::*;
+    use crate::{compile_program_to, CompileResult, CompileStage};
+
+
+    /// Tests the traversal by generating symbol tables for every file.
+    #[test]
+    fn test_attributes() {
+        test_on_dsl_files("BraneScript", |path, code| {
+            // Start by the name to always know which file this is
+            println!("{}", (0..80).map(|_| '-').collect::<String>());
+            println!("File '{}' gave us:", path.display());
+
+            // Load the package index
+            let pindex: PackageIndex = create_package_index();
+            let dindex: DataIndex = create_data_index();
+
+            let program: Program = match compile_program_to(code.as_bytes(), &pindex, &dindex, &ParserOptions::bscript(), CompileStage::Attributes) {
+                CompileResult::Program(p, warns) => {
+                    // Print warnings if any
+                    for w in warns {
+                        w.prettyprint(path.to_string_lossy(), &code);
+                    }
+                    p
+                },
+                CompileResult::Eof(err) => {
+                    // Print the error
+                    err.prettyprint(path.to_string_lossy(), &code);
+                    panic!("Failed to process attributes (see output above)");
+                },
+                CompileResult::Err(errs) => {
+                    // Print the errors
+                    for e in errs {
+                        e.prettyprint(path.to_string_lossy(), &code);
+                    }
+                    panic!("Failed to process attributes (see output above)");
+                },
+
+                _ => {
+                    unreachable!();
+                },
+            };
+
+            // Now print the symbol tables for prettyness
+            dsl::do_traversal(program, std::io::stdout()).unwrap();
+            println!("{}\n\n", (0..80).map(|_| '-').collect::<String>());
+        });
+    }
+}
+
+
+
+
+
+/***** TRAVERSAL FUNCTIONS *****/
+/// Traverses a block to process annotation statements.
+///
+/// # Arguments
+/// - `block`: The [`Block`] to traverse.
+/// - `prev_attrs`: The attributes returned by the previous statement if it was a [`Stmt::Attribute`], or else an empty vector.
+/// - `warns`: A list to keep track of warnings that occur.
+fn pass_block(block: &mut Block, prev_attrs: Vec<Attribute>, warns: &mut Vec<Warning>) {
+    let Block { stmts, table: _, ret_type: _, attrs, range: _ } = block;
+
+    // Set the attributes passed from the previous one
+    attrs.extend(prev_attrs);
+
+    // Simply pass its statements
+    let mut next_attrs: Vec<Attribute> = vec![];
+    for s in stmts.iter_mut() {
+        // Pass it with this block's attribute list as parent, though
+        next_attrs = pass_stmt(s, attrs, next_attrs, warns);
+    }
+
+    // Warn about final attributes not found
+    for attr in next_attrs {
+        warns.push(Warning::UnmatchedAttribute { range: attr.range().clone() });
+    }
+
+    // Retain only non-attribute statements
+    stmts.retain(|s| !matches!(s, Stmt::Attribute(_)) && !matches!(s, Stmt::AttributeInner(_)));
+}
+
+/// Traverses a statement to process annotation statements.
+///
+/// # Arguments
+/// - `stmt`: The [`Stmt`] to traverse.
+/// - `parent_attrs`: A list of the parent attributes, updated when we find a [`Stmt::AttributeInner`].
+/// - `prev_attrs`: The attributes returned by the previous statement if it was a [`Stmt::Attribute`], or else an empty vector.
+/// - `warns`: A list to keep track of warnings that occur.
+///
+/// # Returns
+/// The attributes returned by this statement if it was a [`Stmt::Attribute`], or else an empty vector.
+fn pass_stmt(stmt: &mut Stmt, parent_attrs: &mut Vec<Attribute>, mut prev_attrs: Vec<Attribute>, warns: &mut Vec<Warning>) -> Vec<Attribute> {
+    // Match on the statement
+    use Stmt::*;
+    match stmt {
+        Stmt::Attribute(attr) => {
+            // Add the attributes as next one
+            prev_attrs.push(attr.clone());
+            prev_attrs
+        },
+        Stmt::AttributeInner(attr) => {
+            // Add the attributes to the parent
+            parent_attrs.push(attr.clone());
+            vec![]
+        },
+
+        Stmt::Block { block } => {
+            pass_block(block, prev_attrs, warns);
+            vec![]
+        },
+
+        Stmt::Import { name: _, version: _, st_funcs: _, st_classes: _, attrs, range: _ } => {
+            // Set the previous attributes
+            attrs.extend(prev_attrs);
+            vec![]
+        },
+        Stmt::FuncDef { ident: _, params: _, code, st_entry: _, attrs, range: _ } => {
+            // Set the previous attributes
+            attrs.extend(prev_attrs.clone());
+
+            // Traverse the body
+            pass_block(code, prev_attrs, warns);
+            vec![]
+        },
+        Stmt::ClassDef { ident: _, props: _, methods, st_entry: _, symbol_table: _, attrs, range: _ } => {
+            // Set the previous attributes
+            attrs.extend(prev_attrs.clone());
+
+            // Traverse the methods
+            for method in methods {
+                pass_stmt(method, parent_attrs, prev_attrs.clone(), warns);
+            }
+            vec![]
+        },
+        Return { expr: _, data_type: _, output: _, attrs, range: _ } => {
+            attrs.extend(prev_attrs);
+            vec![]
+        },
+
+        If { cond: _, consequent, alternative, attrs, range: _ } => {
+            attrs.extend(prev_attrs.clone());
+
+            // Pass the blocks
+            pass_block(consequent, prev_attrs.clone(), warns);
+            if let Some(alternative) = alternative {
+                pass_block(alternative, prev_attrs, warns);
+            }
+            vec![]
+        },
+        For { initializer: _, condition: _, increment: _, consequent, attrs, range: _ } => {
+            attrs.extend(prev_attrs.clone());
+            pass_block(consequent, prev_attrs, warns);
+            vec![]
+        },
+        While { condition: _, consequent, attrs, range: _ } => {
+            attrs.extend(prev_attrs.clone());
+            pass_block(consequent, prev_attrs, warns);
+            vec![]
+        },
+        Parallel { result: _, blocks, merge: _, st_entry: _, attrs, range: _ } => {
+            attrs.extend(prev_attrs.clone());
+            for block in blocks {
+                pass_block(block, prev_attrs.clone(), warns);
+            }
+            vec![]
+        },
+
+        LetAssign { name: _, value: _, st_entry: _, attrs, range: _ } => {
+            attrs.extend(prev_attrs.clone());
+            vec![]
+        },
+        Assign { name: _, value: _, st_entry: _, attrs, range: _ } => {
+            attrs.extend(prev_attrs.clone());
+            vec![]
+        },
+        Expr { expr: _, data_type: _, attrs, range: _ } => {
+            attrs.extend(prev_attrs.clone());
+            vec![]
+        },
+
+        Empty {} => vec![],
+    }
+}
+
+
+
+
+
+/***** LIBRARY *****/
+/// Processes annotation statements into annotations on the other statements in the AST.
+///
+/// The goal of this traversal is to get rid of [`Stmt::Attribute`] and [`Stmt::AttributeInner`] occurrances, populating the `attrs`-field in various [`Stmt`] variants.
+///
+/// # Arguments
+/// - `root`: The root node of the tree on which this compiler pass will be done.
+///
+/// # Returns
+/// The same nodes as went in, but now with annotation statements translated to annotations on structs.
+///
+/// # Errors
+/// This pass may throw multiple `AstError::NullError`s if the user made mistakes with their variable references.
+pub fn do_traversal(mut root: Program, warnings: &mut Vec<AstWarning>) -> Result<Program, Vec<AstError>> {
+    // Traverse the tree, doin' all the work
+    let mut warns: Vec<Warning> = vec![];
+    pass_block(&mut root.block, vec![], &mut warns);
+
+    // Process the warnings
+    warnings.extend(warns.into_iter().map(AstWarning::AttributesWarning));
+
+    // Returns the errors
+    Ok(root)
+}

--- a/brane-ast/src/traversals/attributes.rs
+++ b/brane-ast/src/traversals/attributes.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    08 Dec 2023, 11:35:48
 //  Last edited:
-//    08 Dec 2023, 17:07:47
+//    12 Dec 2023, 16:35:31
 //  Auto updated?
 //    Yes
 //
@@ -149,19 +149,21 @@ fn pass_stmt(stmt: &mut Stmt, parent_attrs: &mut Vec<Attribute>, mut prev_attrs:
         },
         FuncDef { ident: _, params: _, code, st_entry: _, attrs, range: _ } => {
             // Set the previous attributes
-            attrs.extend(prev_attrs.clone());
+            attrs.extend(prev_attrs);
 
             // Traverse the body
-            pass_block(code, prev_attrs, warns);
+            // Note: we pass empty because the attributes to the class have already been given
+            pass_block(code, vec![], warns);
             vec![]
         },
         ClassDef { ident: _, props: _, methods, st_entry: _, symbol_table: _, attrs, range: _ } => {
             // Set the previous attributes
-            attrs.extend(prev_attrs.clone());
+            attrs.extend(prev_attrs);
 
             // Traverse the methods
             for method in methods {
-                pass_stmt(method, parent_attrs, prev_attrs.clone(), warns);
+                // Note: we pass empty because the attributes to the class have already been given
+                pass_stmt(method, parent_attrs, vec![], warns);
             }
             vec![]
         },
@@ -171,43 +173,47 @@ fn pass_stmt(stmt: &mut Stmt, parent_attrs: &mut Vec<Attribute>, mut prev_attrs:
         },
 
         If { cond: _, consequent, alternative, attrs, range: _ } => {
-            attrs.extend(prev_attrs.clone());
+            attrs.extend(prev_attrs);
 
             // Pass the blocks
-            pass_block(consequent, prev_attrs.clone(), warns);
+            pass_block(consequent, vec![], warns);
             if let Some(alternative) = alternative {
-                pass_block(alternative, prev_attrs, warns);
+                // Note: we pass empty because the attributes to the class have already been given
+                pass_block(alternative, vec![], warns);
             }
             vec![]
         },
         For { initializer: _, condition: _, increment: _, consequent, attrs, range: _ } => {
-            attrs.extend(prev_attrs.clone());
-            pass_block(consequent, prev_attrs, warns);
+            attrs.extend(prev_attrs);
+            // Note: we pass empty because the attributes to the class have already been given
+            pass_block(consequent, vec![], warns);
             vec![]
         },
         While { condition: _, consequent, attrs, range: _ } => {
-            attrs.extend(prev_attrs.clone());
-            pass_block(consequent, prev_attrs, warns);
+            attrs.extend(prev_attrs);
+            // Note: we pass empty because the attributes to the class have already been given
+            pass_block(consequent, vec![], warns);
             vec![]
         },
         Parallel { result: _, blocks, merge: _, st_entry: _, attrs, range: _ } => {
-            attrs.extend(prev_attrs.clone());
+            attrs.extend(prev_attrs);
             for block in blocks {
-                pass_block(block, prev_attrs.clone(), warns);
+                // Note: we pass empty because the attributes to the class have already been given
+                pass_block(block, vec![], warns);
             }
             vec![]
         },
 
         LetAssign { name: _, value: _, st_entry: _, attrs, range: _ } => {
-            attrs.extend(prev_attrs.clone());
+            attrs.extend(prev_attrs);
             vec![]
         },
         Assign { name: _, value: _, st_entry: _, attrs, range: _ } => {
-            attrs.extend(prev_attrs.clone());
+            attrs.extend(prev_attrs);
             vec![]
         },
         Expr { expr: _, data_type: _, attrs, range: _ } => {
-            attrs.extend(prev_attrs.clone());
+            attrs.extend(prev_attrs);
             vec![]
         },
 

--- a/brane-ast/src/traversals/flatten.rs
+++ b/brane-ast/src/traversals/flatten.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    15 Sep 2022, 08:26:20
 //  Last edited:
-//    08 Dec 2023, 11:32:25
+//    12 Dec 2023, 15:57:21
 //  Auto updated?
 //    Yes
 //

--- a/brane-ast/src/traversals/flatten.rs
+++ b/brane-ast/src/traversals/flatten.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    15 Sep 2022, 08:26:20
 //  Last edited:
-//    07 Nov 2023, 17:13:49
+//    08 Dec 2023, 11:32:25
 //  Auto updated?
 //    Yes
 //
@@ -20,6 +20,7 @@ use std::rc::Rc;
 use brane_dsl::ast::{Block, Expr, Program, Stmt};
 use brane_dsl::symbol_table::{ClassEntry, FunctionEntry, VarEntry};
 use brane_dsl::SymbolTable;
+use enum_debug::EnumDebug as _;
 
 use crate::errors::AstError;
 pub use crate::errors::FlattenError as Error;
@@ -486,14 +487,10 @@ pub fn pass_stmt(stmt: &mut Stmt, table: &mut TableState, errors: &mut Vec<Error
             pass_expr(condition, table);
             pass_block(consequent, table, errors);
         },
-        On { block, .. } => {
-            // No need to recurse into the location, since that cannot be anything else than a literal at this point
-            pass_block(block, table, errors);
-        },
         Parallel { blocks, st_entry, .. } => {
             // Continue traversal first (the entry is not in scope for that bit)
             for b in blocks {
-                pass_stmt(b, table, errors);
+                pass_block(b, table, errors);
             }
 
             // Define the variable if it exists
@@ -518,7 +515,8 @@ pub fn pass_stmt(stmt: &mut Stmt, table: &mut TableState, errors: &mut Vec<Error
         },
 
         // The rest neither recurses nor defines
-        _ => {},
+        Empty {} => {},
+        Attribute(_) | AttributeInner(_) => panic!("Encountered {:?} in flatten traversal", stmt.variant()),
     }
 }
 

--- a/brane-ast/src/traversals/location.rs
+++ b/brane-ast/src/traversals/location.rs
@@ -1,27 +1,27 @@
 //  LOCATION.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    05 Sep 2022, 16:27:08
 //  Last edited:
-//    23 Dec 2022, 16:35:49
+//    08 Dec 2023, 15:50:21
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Resolves the extra location restrictions that on-structures impose.
-//! 
+//!
 //!   Note that this traversal is actually only here in a deprecated fashion.
-// 
+//
 
 use std::collections::HashSet;
 
-use brane_dsl::TextRange;
+use brane_dsl::ast::{Attribute, Block, Expr, Literal, Node, Program, Stmt};
 use brane_dsl::location::{AllowedLocations, Location};
-use brane_dsl::ast::{Block, Expr, Literal, Node, Program, Stmt};
+use brane_dsl::TextRange;
 
-pub use crate::errors::LocationError as Error;
 use crate::errors::AstError;
+pub use crate::errors::LocationError as Error;
 
 
 /***** TESTS *****/
@@ -31,8 +31,9 @@ mod tests {
     use brane_shr::utilities::{create_data_index, create_package_index, test_on_dsl_files};
     use specifications::data::DataIndex;
     use specifications::package::PackageIndex;
-    use super::*;
+
     use super::super::print::dsl;
+    use super::*;
     use crate::{compile_program_to, CompileResult, CompileStage};
 
 
@@ -46,7 +47,7 @@ mod tests {
 
             // Load the package index
             let pindex: PackageIndex = create_package_index();
-            let dindex: DataIndex    = create_data_index();
+            let dindex: DataIndex = create_data_index();
 
             // Run up to this traversal
             let program: Program = match compile_program_to(code.as_bytes(), &pindex, &dindex, &ParserOptions::bscript(), CompileStage::Location) {
@@ -61,7 +62,7 @@ mod tests {
                     // Print the error
                     err.prettyprint(path.to_string_lossy(), &code);
                     panic!("Failed to analyse locations (see output above)");
-                }
+                },
                 CompileResult::Err(errs) => {
                     // Print the errors
                     for e in errs {
@@ -70,7 +71,9 @@ mod tests {
                     panic!("Failed to analyse locations (see output above)");
                 },
 
-                _ => { unreachable!(); },
+                _ => {
+                    unreachable!();
+                },
             };
 
             // Now print the file for prettyness
@@ -84,145 +87,201 @@ mod tests {
 
 
 
+/***** HELPER FUNCTIONS *****/
+/// Searches the given attributes for `loc`/`location`-attributes and use that to scope the given [`AllowedLocations`].
+///
+/// # Arguments
+/// - `attrs`: The list of attributes to search.
+/// - `locations`: The [`AllowedLocations`] list to scope down.
+/// - `reasons`: A trail of [`TextRange`]s that is used to point to all attributes leading to the current (faultive) scope.
+/// - `errors`: A list used to keep track of occurred errors.
+///
+/// # Errors
+/// This function may error if the current combination of attributes leads to zero possible locations.
+fn process_attrs_loc_location(attrs: &[Attribute], locations: &mut AllowedLocations, reasons: &mut Vec<TextRange>, errors: &mut Vec<Error>) {
+    for attr in attrs {
+        match attr {
+            Attribute::List { key, values, range } => {
+                if key.value == "on" || key.value == "loc" || key.value == "location" {
+                    // Assert the values a literals
+                    let locs: HashSet<Location> = values
+                        .iter()
+                        .filter_map(|value| {
+                            if let Literal::String { value, range: _ } = value {
+                                Some(Location::from(value.clone()))
+                            } else {
+                                errors.push(Error::IllegalLocation { range: value.range().clone() });
+                                None
+                            }
+                        })
+                        .collect();
+
+                    // Compute the intersection with the existing one
+                    locations.intersection(&mut AllowedLocations::Exclusive(locs));
+                    if locations.is_empty() {
+                        errors.push(Error::OnNoLocation { range: range.clone(), reasons: reasons.clone() });
+                        return;
+                    }
+                    // Keep track of where this lives for errors
+                    reasons.push(range.clone());
+                }
+            },
+
+            // Ignore other attributes
+            Attribute::KeyPair { .. } => {},
+        }
+    }
+}
+
+
+
+
+
 /***** TRAVERSAL FUNCTIONS *****/
 /// Attempts to resolve the location restrictions of all function calls in this Stmt.
-/// 
+///
 /// # Arguments
 /// - `stmt`: The Stmt to traverse.
 /// - `locations`: The current restriction of locations as imposed by the on-structs.
 /// - `reasons`: The ranges of the on-structs that somehow restrict the current call.
 /// - `errors`: A list we use to accumulate errors as they occur.
-/// 
+///
 /// # Errors
 /// This function may error if there were semantic problems while resolving the locations.
-/// 
+///
 /// If errors occur, they are appended to the `errors` list. The function is early-quit in that case.
-fn pass_stmt(stmt: &mut Stmt, locations: AllowedLocations, reasons: Vec<TextRange>, errors: &mut Vec<Error>) {
+fn pass_stmt(stmt: &mut Stmt, mut locations: AllowedLocations, mut reasons: Vec<TextRange>, errors: &mut Vec<Error>) {
     // Match on the exact statement
     use Stmt::*;
     #[allow(clippy::collapsible_match)]
     match stmt {
-        Block{ block, .. } => {
+        Block { block } => {
             pass_block(block, locations, reasons, errors);
         },
 
-        FuncDef{ code, .. } => {
+        FuncDef { ident: _, params: _, code, st_entry: _, attrs, range: _ } => {
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
             pass_block(code, locations, reasons, errors);
         },
-        ClassDef{ methods, .. } => {
+        ClassDef { ident: _, props: _, methods, st_entry: _, symbol_table: _, attrs, range: _ } => {
+            // Analyse the attributes for location scopes
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
+
+            // Apply to method bodies
             for m in methods {
                 pass_stmt(m, locations.clone(), reasons.clone(), errors);
             }
         },
-        Return{ expr, .. } => {
-            if let Some(expr) = expr { pass_expr(expr, locations, reasons, errors); }
+        Return { expr, data_type: _, output: _, attrs, range: _ } => {
+            if let Some(expr) = expr {
+                process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
+                pass_expr(expr, locations, reasons, errors);
+            }
         },
 
-        If{ cond, consequent, alternative, .. } => {
+        If { cond, consequent, alternative, attrs, range: _ } => {
+            // Apply attributes
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
+
+            // Pass everything in this statement
             pass_expr(cond, locations.clone(), reasons.clone(), errors);
             pass_block(consequent, locations.clone(), reasons.clone(), errors);
-            if let Some(alternative) = alternative { pass_block(alternative, locations, reasons, errors) };
+            if let Some(alternative) = alternative {
+                pass_block(alternative, locations, reasons, errors)
+            };
         },
-        For{ initializer, condition, increment, consequent, .. } => {
+        For { initializer, condition, increment, consequent, attrs, range: _ } => {
+            // Apply attributes
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
+
+            // Pass everything in this statement
             pass_stmt(initializer, locations.clone(), reasons.clone(), errors);
             pass_expr(condition, locations.clone(), reasons.clone(), errors);
             pass_stmt(increment, locations.clone(), reasons.clone(), errors);
             pass_block(consequent, locations, reasons, errors);
         },
-        While{ condition, consequent, .. } => {
+        While { condition, consequent, attrs, range: _ } => {
+            // Apply attributes
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
+
+            // Pass everything in this statement
             pass_expr(condition, locations.clone(), reasons.clone(), errors);
             pass_block(consequent, locations, reasons, errors);
         },
-        On{ location, block, range, .. } => {
-            // Enfore the location to be a string constant (we do always expect a cast due to type analysis).
-            let loc: String = if let brane_dsl::ast::Expr::Cast { expr, .. } = location {
-                if let brane_dsl::ast::Expr::Literal { literal: Literal::String{ value, .. } } = &**expr {
-                    value.clone()
-                } else {
-                    errors.push(Error::IllegalLocation { range: location.range().clone() });
-                    return;
-                }
-            } else {
-                errors.push(Error::IllegalLocation { range: location.range().clone() });
-                return;
-            };
+        Parallel { blocks, merge: _, result: _, st_entry: _, attrs, range: _ } => {
+            // Apply attributes
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
 
-            // See what this additional restriction imposes
-            let mut locations: AllowedLocations = locations;
-            locations.intersection(&mut AllowedLocations::Exclusive(HashSet::from([ Location::from(loc) ])));
-            if locations.is_empty() {
-                errors.push(Error::OnNoLocation { range: range.clone(), reasons });
-                return;
-            }
-
-            // With the new restrictions set, recurse
-            let mut reasons: Vec<TextRange> = reasons;
-            reasons.push(range.clone());
-            pass_block(block, locations, reasons, errors);
-        },
-        Parallel{ blocks, .. } => {
+            // Pass everything in this statement
             for b in blocks {
-                pass_stmt(b, locations.clone(), reasons.clone(), errors);
+                pass_block(b, locations.clone(), reasons.clone(), errors);
             }
         },
 
-        LetAssign{ value, .. } => {
+        LetAssign { value, name: _, st_entry: _, attrs, range: _ } => {
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
             pass_expr(value, locations, reasons, errors);
         },
-        Assign{ value, .. } => {
+        Assign { name: _, value, st_entry: _, attrs, range: _ } => {
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
             pass_expr(value, locations, reasons, errors);
         },
-        Expr{ expr, .. } => {
+        Expr { expr, data_type: _, attrs, range: _ } => {
+            process_attrs_loc_location(attrs, &mut locations, &mut reasons, errors);
             pass_expr(expr, locations, reasons, errors);
         },
 
         // The rest no matter
-        _ => {},
+        Import { .. } | Empty { .. } => {},
+        Attribute(_) | AttributeInner(_) => {},
     };
 }
 
 /// Attempts to resolve the location restrictions of all function calls in this Block.
-/// 
+///
 /// # Arguments
 /// - `block`: The Block to traverse.
 /// - `locations`: The current restriction of locations as imposed by the on-structs.
 /// - `reasons`: The ranges of the on-structs that somehow restrict the current call.
 /// - `errors`: A list we use to accumulate errors as they occur.
-/// 
+///
 /// # Errors
 /// This function may error if there were semantic problems while resolving the locations.
-/// 
+///
 /// If errors occur, they are appended to the `errors` list. The function is early-quit in that case.
-fn pass_block(block: &mut Block, locations: AllowedLocations, reasons: Vec<TextRange>, errors: &mut Vec<Error>) {
-    // Simply recurse
+fn pass_block(block: &mut Block, mut locations: AllowedLocations, mut reasons: Vec<TextRange>, errors: &mut Vec<Error>) {
+    // Inspect if the block has annotations about the location
+    process_attrs_loc_location(&block.attrs, &mut locations, &mut reasons, errors);
+
+    // Then recurse into the statements with the location restrictions
     for s in &mut block.stmts {
         pass_stmt(s, locations.clone(), reasons.clone(), errors);
     }
 }
 
 /// Attempts to resolve the location restrictions of all function calls in this Expr.
-/// 
+///
 /// # Arguments
 /// - `expr`: The Expr to traverse.
 /// - `on_locations`: The current restriction of locations as imposed by the on-structs.
 /// - `on_reasons`: The ranges of the on-structs that somehow restrict the current call.
 /// - `errors`: A list we use to accumulate errors as they occur.
-/// 
+///
 /// # Returns
 /// This function returns the restrictions of the expression as a whole, together with a list of sources for that restriction. This only applies to calls within it, but is necessary for parent calls to know about.
-/// 
+///
 /// # Errors
 /// This function may error if there were semantic problems while resolving the locations.
-/// 
+///
 /// If errors occur, they are appended to the `errors` list. The function is early-quit in that case.
 fn pass_expr(expr: &mut Expr, on_locations: AllowedLocations, on_reasons: Vec<TextRange>, errors: &mut Vec<Error>) {
     use Expr::*;
     match expr {
-        Cast{ expr, .. } => {
+        Cast { expr, .. } => {
             pass_expr(expr, on_locations, on_reasons, errors);
         },
 
-        Call{ expr, args, ref mut locations, range, .. } => {
+        Call { expr, args, ref mut locations, range, .. } => {
             // Resolve the nested stuff first
             pass_expr(expr, on_locations.clone(), on_reasons.clone(), errors);
             for a in args {
@@ -231,36 +290,40 @@ fn pass_expr(expr: &mut Expr, on_locations: AllowedLocations, on_reasons: Vec<Te
 
             // Add the current location if it added to the restriction
             let mut on_reasons: Vec<TextRange> = on_reasons;
-            if locations.is_exclusive() { on_reasons.push(range.clone()); }
+            if locations.is_exclusive() {
+                on_reasons.push(range.clone());
+            }
 
             // Take the union of the already imposed restrictions + those imposed by On-blocks
             let mut on_locations: AllowedLocations = on_locations;
             locations.intersection(&mut on_locations);
-            if locations.is_empty() { errors.push(Error::NoLocation { range: range.clone(), reasons: on_reasons }); }
+            if locations.is_empty() {
+                errors.push(Error::NoLocation { range: range.clone(), reasons: on_reasons });
+            }
         },
-        Array{ values, .. } => {
+        Array { values, .. } => {
             for v in values {
                 pass_expr(v, on_locations.clone(), on_reasons.clone(), errors);
             }
         },
-        ArrayIndex{ array, index, .. } => {
+        ArrayIndex { array, index, .. } => {
             pass_expr(array, on_locations.clone(), on_reasons.clone(), errors);
             pass_expr(index, on_locations, on_reasons, errors);
         },
 
-        UnaOp{ expr, .. } => {
+        UnaOp { expr, .. } => {
             pass_expr(expr, on_locations, on_reasons, errors);
         },
-        BinOp{ lhs, rhs, .. } => {
+        BinOp { lhs, rhs, .. } => {
             pass_expr(lhs, on_locations.clone(), on_reasons.clone(), errors);
             pass_expr(rhs, on_locations, on_reasons, errors);
         },
-        Proj{ lhs, rhs, .. } => {
+        Proj { lhs, rhs, .. } => {
             pass_expr(lhs, on_locations.clone(), on_reasons.clone(), errors);
             pass_expr(rhs, on_locations, on_reasons, errors);
         },
 
-        Instance{ properties, .. } => {
+        Instance { properties, .. } => {
             for p in properties {
                 pass_expr(&mut p.value, on_locations.clone(), on_reasons.clone(), errors);
             }
@@ -277,17 +340,17 @@ fn pass_expr(expr: &mut Expr, on_locations: AllowedLocations, on_reasons: Vec<Te
 
 /***** LIBRARY *****/
 /// Resolves typing in the given `brane-dsl` AST.
-/// 
+///
 /// Note that the symbol tables must already have been constructed.
-/// 
+///
 /// This effectively resolves all unresolved types in the symbol tables and verifies everything is compatible. Additionally, it may also insert implicit type casts where able.
-/// 
+///
 /// # Arguments
 /// - `root`: The root node of the tree on which this compiler pass will be done.
-/// 
+///
 /// # Returns
 /// The same nodes as went in, but now with no unresolved types.
-/// 
+///
 /// # Errors
 /// This pass may throw multiple `AstError::ResolveError`s if the user made mistakes with their variable references.
 pub fn do_traversal(root: Program) -> Result<Program, Vec<AstError>> {
@@ -300,9 +363,5 @@ pub fn do_traversal(root: Program) -> Result<Program, Vec<AstError>> {
     }
 
     // Done
-    if errors.is_empty() {
-        Ok(root)
-    } else {
-        Err(errors.into_iter().map(|e| e.into()).collect())
-    }
+    if errors.is_empty() { Ok(root) } else { Err(errors.into_iter().map(|e| e.into()).collect()) }
 }

--- a/brane-ast/src/traversals/location.rs
+++ b/brane-ast/src/traversals/location.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    05 Sep 2022, 16:27:08
 //  Last edited:
-//    08 Dec 2023, 16:34:17
+//    08 Dec 2023, 17:16:27
 //  Auto updated?
 //    Yes
 //
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 use brane_dsl::ast::{Attribute, Block, Expr, Literal, Node, Program, Stmt};
 use brane_dsl::location::{AllowedLocations, Location};
 use brane_dsl::TextRange;
+use enum_debug::EnumDebug as _;
 
 use crate::errors::AstError;
 pub use crate::errors::LocationError as Error;
@@ -234,7 +235,7 @@ fn pass_stmt(stmt: &mut Stmt, mut locations: AllowedLocations, mut reasons: Vec<
 
         // The rest no matter
         Import { .. } | Empty { .. } => {},
-        Attribute(_) | AttributeInner(_) => {},
+        Attribute(_) | AttributeInner(_) => panic!("Encountered {:?} in location traversal", stmt.variant()),
     };
 }
 

--- a/brane-ast/src/traversals/metadata.rs
+++ b/brane-ast/src/traversals/metadata.rs
@@ -1,0 +1,362 @@
+//  METADATA.rs
+//    by Lut99
+//
+//  Created:
+//    08 Dec 2023, 16:34:54
+//  Last edited:
+//    08 Dec 2023, 18:03:16
+//  Auto updated?
+//    Yes
+//
+//  Description:
+//!   Traversal that annotates the given workflow with metadata from tags.
+//
+
+use std::collections::HashMap;
+
+use brane_dsl::ast::{Attribute, Block, Expr, Literal, Node as _, Program, Stmt};
+use brane_dsl::TextRange;
+use enum_debug::EnumDebug as _;
+
+use crate::errors::AstError;
+use crate::warnings::AstWarning;
+pub use crate::warnings::MetadataWarning as Warning;
+
+
+/***** TESTS *****/
+#[cfg(test)]
+mod tests {
+    use brane_dsl::ParserOptions;
+    use brane_shr::utilities::{create_data_index, create_package_index, test_on_dsl_files};
+    use specifications::data::DataIndex;
+    use specifications::package::PackageIndex;
+
+    use super::super::print::dsl;
+    use super::*;
+    use crate::{compile_program_to, CompileResult, CompileStage};
+
+
+    /// Tests the traversal by generating symbol tables for every file.
+    #[test]
+    fn test_metadata() {
+        test_on_dsl_files("BraneScript", |path, code| {
+            // Start by the name to always know which file this is
+            println!("{}", (0..80).map(|_| '-').collect::<String>());
+            println!("File '{}' gave us:", path.display());
+
+            // Load the package index
+            let pindex: PackageIndex = create_package_index();
+            let dindex: DataIndex = create_data_index();
+
+            let program: Program = match compile_program_to(code.as_bytes(), &pindex, &dindex, &ParserOptions::bscript(), CompileStage::Metadata) {
+                CompileResult::Program(p, warns) => {
+                    // Print warnings if any
+                    for w in warns {
+                        w.prettyprint(path.to_string_lossy(), &code);
+                    }
+                    p
+                },
+                CompileResult::Eof(err) => {
+                    // Print the error
+                    err.prettyprint(path.to_string_lossy(), &code);
+                    panic!("Failed to process tags (see output above)");
+                },
+                CompileResult::Err(errs) => {
+                    // Print the errors
+                    for e in errs {
+                        e.prettyprint(path.to_string_lossy(), &code);
+                    }
+                    panic!("Failed to process tags (see output above)");
+                },
+
+                _ => {
+                    unreachable!();
+                },
+            };
+
+            // Now print the symbol tables for prettyness
+            dsl::do_traversal(program, std::io::stdout()).unwrap();
+            println!("{}\n\n", (0..80).map(|_| '-').collect::<String>());
+        });
+    }
+}
+
+
+
+
+
+/***** HELPER FUNCTIONS *****/
+/// Searches the given attributes for `tag`/`metadata`-attributes and use that to apply metadata-tags.
+///
+/// # Arguments
+/// - `attrs`: The list of attributes to search.
+/// - `metadata`: A list of tags already in scope (and where they are defined).
+/// - `is_workflow`: Whether we're collecting workflow tags or not.
+/// - `warns`: A list used to keep track of occurred warns.
+///
+/// # Errors
+/// This function may error if the current combination of attributes leads to zero possible locations.
+fn process_attrs_loc_location(attrs: &[Attribute], metadata: &mut HashMap<String, TextRange>, is_workflow: bool, warns: &mut Vec<Warning>) {
+    for attr in attrs {
+        match attr {
+            Attribute::List { key, values, range } => {
+                if (is_workflow
+                    && (key.value == "wf_tag" || key.value == "wf_metadata" || key.value == "workflow_tag" || key.value == "workflow_metadata"))
+                    || (!is_workflow && (key.value == "tag" || key.value == "metadata"))
+                {
+                    // Add the tag's tags to the current list
+                    for value in values {
+                        // Get the string value
+                        let (value, range) = if let Literal::String { value, range: _ } = value {
+                            (value.clone(), range.clone())
+                        } else {
+                            warns.push(Warning::NonStringTag { range: value.range().clone() });
+                            continue;
+                        };
+
+                        // Move the metadata to the thing
+                        if let Some(prev) = metadata.get(&value) {
+                            warns.push(Warning::DuplicateTag { prev: prev.clone(), range });
+                        } else {
+                            metadata.insert(value, range);
+                        }
+                    }
+                }
+            },
+
+            // Ignore other attributes
+            Attribute::KeyPair { .. } => {},
+        }
+    }
+}
+
+/// Warns users for attributes that have no effect.
+///
+/// # Arguments
+/// - `attrs`: The list of attributes to search.
+/// - `warns`: A list used to keep track of occurred warns.
+fn warn_useless_attrs(attrs: &[Attribute], warns: &mut Vec<Warning>) {
+    // Collect the attributes
+    let mut metadata: HashMap<String, TextRange> = HashMap::new();
+    process_attrs_loc_location(attrs, &mut metadata, false, warns);
+
+    // Warn
+    for range in metadata.into_values() {
+        warns.push(Warning::UselessTag { range });
+    }
+}
+
+
+
+
+
+/***** TRAVERSAL FUNCTIONS *****/
+/// Passes a [`Block`].
+///
+/// # Arguments
+/// - `block`: The [`Block`] to traverse.
+/// - `metadata`: The current metadata in scope to apply to applicable things (and where they are defined).
+/// - `warns`: A list that keeps track of warnings that occurred.
+fn pass_block(block: &mut Block, mut metadata: HashMap<String, TextRange>, warns: &mut Vec<Warning>) {
+    // Process block attributes
+    process_attrs_loc_location(&block.attrs, &mut metadata, false, warns);
+
+    // Process the statements
+    for stmt in &mut block.stmts {
+        pass_stmt(stmt, metadata.clone(), warns);
+    }
+}
+
+/// Passes a [`Stmt`].
+///
+/// # Arguments
+/// - `stmt`: The [`Stmt`] to traverse.
+/// - `metadata`: The current metadata in scope to apply to applicable things (and where they are defined).
+/// - `warns`: A list that keeps track of warnings that occurred.
+fn pass_stmt(stmt: &mut Stmt, mut metadata: HashMap<String, TextRange>, warns: &mut Vec<Warning>) {
+    // Match on the statement
+    use Stmt::*;
+    match stmt {
+        Block { block } => {
+            pass_block(block, metadata, warns);
+        },
+
+        Import { name: _, version: _, st_classes: _, st_funcs: _, attrs, range: _ } => {
+            // Remind the user metadata is useless here
+            warn_useless_attrs(attrs, warns);
+        },
+        FuncDef { ident: _, params: _, code, st_entry: _, attrs, range: _ } => {
+            // Remind the user metadata is useless here
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+
+            // Traverse the body
+            pass_block(code, metadata, warns);
+        },
+        ClassDef { ident: _, props: _, methods, st_entry: _, symbol_table: _, attrs, range: _ } => {
+            // Remind the user metadata is useless here
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+            // Traverse the methods
+            for method in methods {
+                pass_stmt(method, metadata.clone(), warns);
+            }
+        },
+        Return { expr, data_type: _, output: _, attrs, range: _ } => {
+            // Traverse into the expression if there is any
+            if let Some(expr) = expr {
+                process_attrs_loc_location(attrs, &mut metadata, false, warns);
+                pass_expr(expr, &metadata, warns);
+            }
+        },
+
+        If { cond, consequent, alternative, attrs, range: _ } => {
+            // Process attributes for the expression
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+
+            // Traverse into the expression, then bodies
+            pass_expr(cond, &metadata, warns);
+            pass_block(consequent, metadata.clone(), warns);
+            if let Some(alternative) = alternative {
+                pass_block(alternative, metadata, warns);
+            }
+        },
+        For { initializer, condition, increment, consequent, attrs, range: _ } => {
+            // Process attributes for the expression
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+
+            // Traverse into the expressions, then bodies
+            pass_stmt(initializer, metadata.clone(), warns);
+            pass_expr(condition, &metadata, warns);
+            pass_stmt(increment, metadata.clone(), warns);
+            pass_block(consequent, metadata, warns);
+        },
+        While { condition, consequent, attrs, range: _ } => {
+            // Process attributes for the expression
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+
+            // Traverse into the expressions, then bodies
+            pass_expr(condition, &metadata, warns);
+            pass_block(consequent, metadata, warns);
+        },
+        Parallel { result: _, blocks, merge: _, st_entry: _, attrs, range: _ } => {
+            // Process attributes for the expression
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+
+            // Traverse into the bodies
+            for block in blocks {
+                pass_block(block, metadata.clone(), warns);
+            }
+        },
+
+        LetAssign { name: _, value, st_entry: _, attrs, range: _ } => {
+            // Process attributes for the expression
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+            // Process the expression
+            pass_expr(value, &metadata, warns);
+        },
+        Assign { name: _, value, st_entry: _, attrs, range: _ } => {
+            // Process attributes for the expression
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+            // Process the expression
+            pass_expr(value, &metadata, warns);
+        },
+        Expr { expr, data_type: _, attrs, range: _ } => {
+            // Process attributes for the expression
+            process_attrs_loc_location(attrs, &mut metadata, false, warns);
+            // Process the expression
+            pass_expr(expr, &metadata, warns);
+        },
+
+        Empty {} => {},
+        Attribute(_) | AttributeInner(_) => panic!("Encountered {:?} in metadata traversal", stmt.variant()),
+    }
+}
+
+/// Passes an [`Expr`].
+///
+/// # Arguments
+/// - `expr`: The [`Expr`] to traverse.
+/// - `metadata`: The current metadata in scope to apply to applicable things (and where they are defined).
+/// - `warns`: A list that keeps track of warnings that occurred.
+fn pass_expr(expr: &mut Expr, metadata: &HashMap<String, TextRange>, warns: &mut Vec<Warning>) {
+    // Match on the expression
+    use Expr::*;
+    match expr {
+        Cast { expr, target: _, range: _ } => pass_expr(expr, metadata, warns),
+
+        Call { expr, args, st_entry, locations: _, input: _, result: _, metadata: call_metadata, range: _ } => {
+            // Examine if it's an external call
+            if st_entry.as_ref().map(|entry| entry.borrow().package_name.is_some()).unwrap_or(false) {
+                call_metadata.extend(metadata.keys().cloned());
+            }
+
+            // Otherwise, recurse into the expressions
+            pass_expr(expr, metadata, warns);
+            for arg in args {
+                pass_expr(arg, metadata, warns);
+            }
+        },
+        Array { values, data_type: _, range: _ } => {
+            for value in values {
+                pass_expr(value, metadata, warns);
+            }
+        },
+        ArrayIndex { array, index, data_type: _, range: _ } => {
+            pass_expr(array, metadata, warns);
+            pass_expr(index, metadata, warns);
+        },
+
+        UnaOp { op: _, expr, range: _ } => pass_expr(expr, metadata, warns),
+        BinOp { op: _, lhs, rhs, range: _ } => {
+            pass_expr(lhs, metadata, warns);
+            pass_expr(rhs, metadata, warns);
+        },
+        Proj { lhs, rhs, st_entry: _, range: _ } => {
+            pass_expr(lhs, metadata, warns);
+            pass_expr(rhs, metadata, warns);
+        },
+
+        Instance { name: _, properties, st_entry: _, range: _ } => {
+            for prop in properties {
+                pass_expr(&mut prop.value, metadata, warns);
+            }
+        },
+
+        // The rest has no chance of hosting a call
+        Pattern { .. } | VarRef { .. } | Identifier { .. } | Literal { .. } | Empty {} => {},
+    }
+}
+
+
+
+
+
+/***** LIBRARY *****/
+/// Processes `#[tag(...)]`/`#[metadata(...)]`-annotations into annotations on various things in the AST.
+///
+/// The goal of this traversal is to populate `metadata`-fields in various AST elements.
+///
+/// # Arguments
+/// - `root`: The root node of the tree on which this compiler pass will be done.
+///
+/// # Returns
+/// The same nodes as went in, but now with annotation statements translated to annotations on structs.
+///
+/// # Errors
+/// This pass may throw multiple `AstError::MetadataError`s if the user made mistakes with their variable references.
+pub fn do_traversal(mut root: Program, warnings: &mut Vec<AstWarning>) -> Result<Program, Vec<AstError>> {
+    let mut warns: Vec<Warning> = vec![];
+
+    // Apply the program attributes to the program metadata
+    let mut root_metadata: HashMap<String, TextRange> = HashMap::new();
+    process_attrs_loc_location(&root.block.attrs, &mut root_metadata, true, &mut warns);
+    root.metadata = root_metadata.into_iter().map(|(tag, _)| tag).collect();
+
+    // Traverse the tree, doin' all the work
+    pass_block(&mut root.block, HashMap::new(), &mut warns);
+
+    // Process the warnings
+    warnings.extend(warns.into_iter().map(AstWarning::MetadataWarning));
+
+    // Returns the errors
+    Ok(root)
+}

--- a/brane-ast/src/traversals/mod.rs
+++ b/brane-ast/src/traversals/mod.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    05 Sep 2022, 10:06:47
 //  Last edited:
-//    08 Dec 2023, 16:36:20
+//    12 Dec 2023, 16:34:00
 //  Auto updated?
 //    Yes
 //
@@ -20,6 +20,7 @@ pub mod flatten;
 pub mod location;
 pub mod metadata;
 pub mod null;
+pub mod offset;
 pub mod print;
 pub mod prune;
 pub mod resolve;

--- a/brane-ast/src/traversals/mod.rs
+++ b/brane-ast/src/traversals/mod.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    05 Sep 2022, 10:06:47
 //  Last edited:
-//    08 Dec 2023, 11:36:11
+//    08 Dec 2023, 16:36:20
 //  Auto updated?
 //    Yes
 //
@@ -18,6 +18,7 @@ pub mod compile;
 pub mod data;
 pub mod flatten;
 pub mod location;
+pub mod metadata;
 pub mod null;
 pub mod print;
 pub mod prune;

--- a/brane-ast/src/traversals/mod.rs
+++ b/brane-ast/src/traversals/mod.rs
@@ -1,26 +1,27 @@
 //  MOD.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    05 Sep 2022, 10:06:47
 //  Last edited:
-//    19 Dec 2022, 10:08:02
+//    08 Dec 2023, 11:36:11
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Defines the traversals that are part of the compiler.
-// 
+//
 
 // Declare the modules
+pub mod attributes;
+pub mod compile;
+pub mod data;
+pub mod flatten;
+pub mod location;
+pub mod null;
 pub mod print;
+pub mod prune;
 pub mod resolve;
 pub mod typing;
-pub mod null;
-pub mod location;
-pub mod data;
-pub mod prune;
-pub mod flatten;
-pub mod compile;
 pub mod workflow_optimize;
 pub mod workflow_resolve;

--- a/brane-ast/src/traversals/null.rs
+++ b/brane-ast/src/traversals/null.rs
@@ -1,22 +1,23 @@
 //  NULL.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    19 Dec 2022, 10:04:38
 //  Last edited:
-//    19 Jan 2023, 10:32:24
+//    08 Dec 2023, 11:09:15
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Implements a traversal that resolves null-types from the tree,
 //!   resolving them with more proper types.
-// 
+//
 
 use brane_dsl::ast::{Block, Expr, Literal, Program, Stmt};
+use enum_debug::EnumDebug as _;
 
-pub use crate::errors::NullError as Error;
 use crate::errors::AstError;
+pub use crate::errors::NullError as Error;
 
 
 /***** TESTS *****/
@@ -26,8 +27,9 @@ mod tests {
     use brane_shr::utilities::{create_data_index, create_package_index, test_on_dsl_files};
     use specifications::data::DataIndex;
     use specifications::package::PackageIndex;
-    use super::*;
+
     use super::super::print::symbol_tables;
+    use super::*;
     use crate::{compile_program_to, CompileResult, CompileStage};
 
 
@@ -41,7 +43,7 @@ mod tests {
 
             // Load the package index
             let pindex: PackageIndex = create_package_index();
-            let dindex: DataIndex    = create_data_index();
+            let dindex: DataIndex = create_data_index();
 
             let program: Program = match compile_program_to(code.as_bytes(), &pindex, &dindex, &ParserOptions::bscript(), CompileStage::Null) {
                 CompileResult::Program(p, warns) => {
@@ -55,7 +57,7 @@ mod tests {
                     // Print the error
                     err.prettyprint(path.to_string_lossy(), &code);
                     panic!("Failed to analyse null-usage (see output above)");
-                }
+                },
                 CompileResult::Err(errs) => {
                     // Print the errors
                     for e in errs {
@@ -64,7 +66,9 @@ mod tests {
                     panic!("Failed to analyse null-usage (see output above)");
                 },
 
-                _ => { unreachable!(); },
+                _ => {
+                    unreachable!();
+                },
             };
 
             // Now print the symbol tables for prettyness
@@ -80,14 +84,14 @@ mod tests {
 
 /***** TRAVERSAL FUNCTIONS *****/
 /// Traverses a Block to find any null-occurances.
-/// 
+///
 /// # Arguments
 /// - `block`: The Block to traverse.
 /// - `errors`: The list that accumulates errors as we do the traversal.
-/// 
+///
 /// # Returns
 /// Nothing, but might change internal nodes to get rid of null-casts.
-/// 
+///
 /// # Errors
 /// This function may error if the user made incorrect usage of `null`. In that case, the error is appended to `errors` and the function might return early.
 fn pass_block(block: &mut Block, errors: &mut Vec<Error>) {
@@ -98,171 +102,168 @@ fn pass_block(block: &mut Block, errors: &mut Vec<Error>) {
 }
 
 /// Traverses a Stmt to find any null-occurances.
-/// 
+///
 /// # Arguments
 /// - `stmt`: The Stmt to traverse.
 /// - `errors`: The list that accumulates errors as we do the traversal.
-/// 
+///
 /// # Returns
 /// Nothing, but might change internal nodes to get rid of null-casts.
-/// 
+///
 /// # Errors
 /// This function may error if the user made incorrect usage of `null`. In that case, the error is appended to `errors` and the function might return early.
 fn pass_stmt(stmt: &mut Stmt, errors: &mut Vec<Error>) {
     // Match on the given statement
     use Stmt::*;
     match stmt {
-        Block{ block } => {
+        Block { block } => {
             pass_block(block, errors);
         },
 
-        FuncDef{ code, .. } => {
+        FuncDef { code, .. } => {
             pass_block(code, errors);
         },
-        ClassDef{ methods, .. } => {
+        ClassDef { methods, .. } => {
             for m in methods {
                 pass_stmt(m, errors);
             }
         },
-        Return{ expr, .. } => {
+        Return { expr, .. } => {
             if let Some(expr) = expr {
                 pass_expr(expr, errors);
             }
         },
 
-        If{ cond, consequent, alternative, .. } => {
+        If { cond, consequent, alternative, .. } => {
             pass_expr(cond, errors);
             pass_block(consequent, errors);
-            if let Some(alternative) = alternative { pass_block(alternative, errors); }
+            if let Some(alternative) = alternative {
+                pass_block(alternative, errors);
+            }
         },
-        For{ initializer, condition, increment, consequent, .. } => {
+        For { initializer, condition, increment, consequent, .. } => {
             pass_stmt(initializer, errors);
             pass_expr(condition, errors);
             pass_stmt(increment, errors);
             pass_block(consequent, errors);
         },
-        While{ condition, consequent, .. } => {
+        While { condition, consequent, .. } => {
             pass_expr(condition, errors);
             pass_block(consequent, errors);
         },
-        On{ block, .. } => {
-            pass_block(block, errors);
-        },
-        Parallel{ blocks, .. } => {
+        Parallel { blocks, .. } => {
             for b in blocks {
-                pass_stmt(b, errors);
+                pass_block(b, errors);
             }
         },
 
-        LetAssign{ value, .. } => {
+        LetAssign { value, .. } => {
             // We'll allow it if this value is a null
             match value {
                 // Null is allowed, and no need to traverse it
-                brane_dsl::ast::Expr::Literal { literal: Literal::Null{ .. } } => {},
+                brane_dsl::ast::Expr::Literal { literal: Literal::Null { .. } } => {},
 
                 // Otherwise, traverse
                 value => pass_expr(value, errors),
             }
         },
-        Assign{ value, .. } => {
+        Assign { value, .. } => {
             // We always crawl since null is not allowed
             pass_expr(value, errors);
         },
-        Expr{ expr, .. } => {
+        Expr { expr, .. } => {
             pass_expr(expr, errors);
         },
 
         // The rest we don't care.
-        Import{ .. } |
-        Empty {}     => {},
+        Import { .. } | Empty {} => {},
+        Attribute(_) | AttributeInner(_) => panic!("Encountered {:?} in resolve traversal", stmt.variant()),
     }
 }
 
 /// Traverses an Expr to get rid of null-casts.
-/// 
+///
 /// Note that at this time, we have already treated any legal null's; so any we find here are always illegal.
-/// 
+///
 /// # Arguments
 /// - `expr`: The Expr to traverse.
 /// - `errors`: The list that accumulates errors as we do the traversal.
-/// 
+///
 /// # Returns
 /// Nothing, but might change this or internal nodes to get rid of null-casts.
-/// 
+///
 /// # Errors
 /// This function may error if the user made incorrect usage of `null`. In that case, the error is appended to `errors` and the function might return early.
 fn pass_expr(expr: &mut Expr, errors: &mut Vec<Error>) {
     // Match the expression given
     use Expr::*;
     match expr {
-        Cast{ expr, .. } => {
+        Cast { expr, .. } => {
             pass_expr(expr, errors);
         },
 
-        Call{ expr, args, .. } => {
+        Call { expr, args, .. } => {
             // Pass 'em all
             pass_expr(expr, errors);
             for a in args {
                 pass_expr(a, errors);
             }
         },
-        Array{ values, .. } => {
+        Array { values, .. } => {
             for v in values {
                 pass_expr(v, errors);
             }
         },
-        ArrayIndex{ array, index, .. } => {
+        ArrayIndex { array, index, .. } => {
             pass_expr(array, errors);
             pass_expr(index, errors);
         },
-        Pattern{ exprs, .. } => {
+        Pattern { exprs, .. } => {
             for e in exprs {
                 pass_expr(e, errors);
             }
         },
 
-        UnaOp{ expr, .. } => {
+        UnaOp { expr, .. } => {
             pass_expr(expr, errors);
         },
-        BinOp{ lhs, rhs, .. } => {
+        BinOp { lhs, rhs, .. } => {
             pass_expr(lhs, errors);
             pass_expr(rhs, errors);
         },
-        Proj{ lhs, rhs, .. } => {
+        Proj { lhs, rhs, .. } => {
             pass_expr(lhs, errors);
             pass_expr(rhs, errors);
         },
 
-        Instance{ properties, .. } => {
+        Instance { properties, .. } => {
             for p in properties {
                 pass_expr(&mut p.value, errors);
             }
         },
-        Literal{ literal } => {
+        Literal { literal } => {
             pass_literal(literal, errors);
         },
 
         // The rest we don't interact with
-        Identifier{ .. } |
-        VarRef{ .. }     |
-        Empty{}          => {},
+        Identifier { .. } | VarRef { .. } | Empty {} => {},
     }
 }
 
 /// Traverses a Literal to detect illegal usage of null.
-/// 
+///
 /// Note that at this time, we have already treated any legal null's; so any we find here are always illegal.
-/// 
+///
 /// # Arguments
 /// - `lit`: The Literal to traverse.
 /// - `errors`: The list that accumulates errors as we do the traversal.
-/// 
+///
 /// # Errors
 /// This function may error if the user made incorrect usage of `null`. In that case, the error is appended to `errors` and the function might return early.
 fn pass_literal(lit: &Literal, errors: &mut Vec<Error>) {
     // We only do one thing: error if we see a `null` here
-    if let Literal::Null{ range } = lit {
-        errors.push(Error::IllegalNull{ range: range.clone() });
+    if let Literal::Null { range } = lit {
+        errors.push(Error::IllegalNull { range: range.clone() });
     }
 }
 
@@ -272,17 +273,17 @@ fn pass_literal(lit: &Literal, errors: &mut Vec<Error>) {
 
 /***** LIBRARY *****/
 /// Resolves null-typing in the given `brane-dsl` AST.
-/// 
+///
 /// Note that the symbol tables must already have been constructed.
-/// 
+///
 /// The goal of this traversal is to get rid of `DataType::Null` occurrances, asserting that null is only used in let-assignments.
-/// 
+///
 /// # Arguments
 /// - `root`: The root node of the tree on which this compiler pass will be done.
-/// 
+///
 /// # Returns
 /// The same nodes as went in, but now with proper null-usage.
-/// 
+///
 /// # Errors
 /// This pass may throw multiple `AstError::NullError`s if the user made mistakes with their variable references.
 pub fn do_traversal(root: Program) -> Result<Program, Vec<AstError>> {
@@ -293,9 +294,5 @@ pub fn do_traversal(root: Program) -> Result<Program, Vec<AstError>> {
     pass_block(&mut root.block, &mut errors);
 
     // Returns the errors
-    if errors.is_empty() {
-        Ok(root)
-    } else {
-        Err(errors.into_iter().map(|e| e.into()).collect())
-    }
+    if errors.is_empty() { Ok(root) } else { Err(errors.into_iter().map(|e| e.into()).collect()) }
 }

--- a/brane-ast/src/traversals/offset.rs
+++ b/brane-ast/src/traversals/offset.rs
@@ -1,0 +1,343 @@
+//  OFFSET.rs
+//    by Lut99
+//
+//  Created:
+//    12 Dec 2023, 16:33:38
+//  Last edited:
+//    12 Dec 2023, 17:13:38
+//  Auto updated?
+//    Yes
+//
+//  Description:
+//!   Secret first first first traversal that simply updates all
+//!   [`TextRange`]s in the AST to have correct offsets w.r.t. the entire
+//!   source (in case this is a snippet).
+//
+
+use brane_dsl::ast::{BinOp, Block, Expr, Identifier, Literal, Program, Property, PropertyExpr, Stmt, UnaOp};
+
+use crate::errors::AstError;
+use crate::state::CompileState;
+
+
+/***** HELPER MACROS *****/
+/// Applies an offset to the given TextRange if it is not none.
+macro_rules! offset_range {
+    ($range:expr, $offset:expr) => {
+        if $range.is_some() {
+            $range.start.line += $offset;
+            $range.end.line += $offset;
+        }
+    };
+}
+
+
+
+
+
+/***** TRAVERSAL FUNCTIONS *****/
+/// Tarverses a [`Block`] to update its range offsets.
+///
+/// # Arguments
+/// - `block`: The [`Block`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+fn pass_block(block: &mut Block, offset: usize) {
+    // Fix the range of this block itself
+    offset_range!(block.range, offset);
+    // ...and of all its statements, of course
+    for stmt in &mut block.stmts {
+        pass_stmt(stmt, offset);
+    }
+}
+
+/// Tarverses a [`Stmt`] to update its range offsets.
+///
+/// # Arguments
+/// - `stmt`: The [`Stmt`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+fn pass_stmt(stmt: &mut Stmt, offset: usize) {
+    // Match the statement
+    use Stmt::*;
+    match stmt {
+        Attribute(attr) | AttributeInner(attr) => match attr {
+            brane_dsl::ast::Attribute::KeyPair { key, value, range } => {
+                pass_ident(key, offset);
+                pass_literal(value, offset);
+                offset_range!(range, offset);
+            },
+            brane_dsl::ast::Attribute::List { key, values, range } => {
+                pass_ident(key, offset);
+                for value in values {
+                    pass_literal(value, offset);
+                }
+                offset_range!(range, offset);
+            },
+        },
+
+        Block { block } => pass_block(block, offset),
+
+        Import { name, version, st_funcs: _, st_classes: _, attrs: _, range } => {
+            pass_ident(name, offset);
+            pass_literal(version, offset);
+            offset_range!(range, offset);
+        },
+        FuncDef { ident, params, code, st_entry: _, attrs: _, range } => {
+            pass_ident(ident, offset);
+            for param in params {
+                pass_ident(param, offset);
+            }
+            pass_block(code, offset);
+            offset_range!(range, offset);
+        },
+        ClassDef { ident, props, methods, st_entry: _, symbol_table: _, attrs: _, range } => {
+            pass_ident(ident, offset);
+            for prop in props {
+                pass_prop(prop, offset);
+            }
+            for method in methods {
+                pass_stmt(method, offset);
+            }
+            offset_range!(range, offset);
+        },
+        Return { expr, data_type: _, output: _, attrs: _, range } => {
+            if let Some(expr) = expr {
+                pass_expr(expr, offset);
+            }
+            offset_range!(range, offset);
+        },
+
+        If { cond, consequent, alternative, attrs: _, range } => {
+            pass_expr(cond, offset);
+            pass_block(consequent, offset);
+            if let Some(alternative) = alternative {
+                pass_block(alternative, offset);
+            }
+            offset_range!(range, offset);
+        },
+        For { initializer, condition, increment, consequent, attrs: _, range } => {
+            pass_stmt(initializer, offset);
+            pass_expr(condition, offset);
+            pass_stmt(increment, offset);
+            pass_block(consequent, offset);
+            offset_range!(range, offset);
+        },
+        While { condition, consequent, attrs: _, range } => {
+            pass_expr(condition, offset);
+            pass_block(consequent, offset);
+            offset_range!(range, offset);
+        },
+        Parallel { result, blocks, merge, st_entry: _, attrs: _, range } => {
+            if let Some(result) = result {
+                pass_ident(result, offset);
+            }
+            for block in blocks {
+                pass_block(block, offset);
+            }
+            if let Some(merge) = merge {
+                pass_ident(merge, offset);
+            }
+            offset_range!(range, offset);
+        },
+
+        LetAssign { name, value, st_entry: _, attrs: _, range } => {
+            pass_ident(name, offset);
+            pass_expr(value, offset);
+            offset_range!(range, offset);
+        },
+        Assign { name, value, st_entry: _, attrs: _, range } => {
+            pass_ident(name, offset);
+            pass_expr(value, offset);
+            offset_range!(range, offset);
+        },
+        Expr { expr, data_type: _, attrs: _, range } => {
+            pass_expr(expr, offset);
+            offset_range!(range, offset);
+        },
+
+        Empty {} => {},
+    }
+}
+
+/// Traverses an [`Identifier`] to update its range offsets.
+///
+/// # Arguments
+/// - `ident`: The [`Identifier`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+#[inline]
+fn pass_ident(ident: &mut Identifier, offset: usize) {
+    let Identifier { value: _, range } = ident;
+    offset_range!(range, offset);
+}
+
+/// Traverses a [`Property`] to update its range offsets.
+///
+/// # Arguments
+/// - `prop`: The [`Property`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+fn pass_prop(prop: &mut Property, offset: usize) {
+    let Property { name, data_type: _, st_entry: _, range } = prop;
+    pass_ident(name, offset);
+    offset_range!(range, offset);
+}
+
+/// Traverses an [`Expr`] to update its range offsets.
+///
+/// # Arguments
+/// - `expr`: The [`Expr`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+fn pass_expr(expr: &mut Expr, offset: usize) {
+    // Match the expression
+    use Expr::*;
+    match expr {
+        Cast { expr, target: _, range } => {
+            pass_expr(expr, offset);
+            offset_range!(range, offset);
+        },
+
+        Call { expr, args, st_entry: _, locations: _, input: _, result: _, metadata: _, range } => {
+            pass_expr(expr, offset);
+            for arg in args {
+                pass_expr(arg, offset);
+            }
+            offset_range!(range, offset);
+        },
+        Array { values, data_type: _, range } => {
+            for value in values {
+                pass_expr(value, offset);
+            }
+            offset_range!(range, offset);
+        },
+        ArrayIndex { array, index, data_type: _, range } => {
+            pass_expr(array, offset);
+            pass_expr(index, offset);
+            offset_range!(range, offset);
+        },
+        Pattern { exprs, range } => {
+            for expr in exprs {
+                pass_expr(expr, offset);
+            }
+            offset_range!(range, offset);
+        },
+
+        UnaOp { op, expr, range } => {
+            pass_una_op(op, offset);
+            pass_expr(expr, offset);
+            offset_range!(range, offset);
+        },
+        BinOp { op, lhs, rhs, range } => {
+            pass_bin_op(op, offset);
+            pass_expr(lhs, offset);
+            pass_expr(rhs, offset);
+            offset_range!(range, offset);
+        },
+        Proj { lhs, rhs, st_entry: _, range } => {
+            pass_expr(lhs, offset);
+            pass_expr(rhs, offset);
+            offset_range!(range, offset);
+        },
+
+        Instance { name, properties, st_entry: _, range } => {
+            pass_ident(name, offset);
+            for property in properties {
+                pass_prop_expr(property, offset);
+            }
+            offset_range!(range, offset);
+        },
+        Identifier { name, st_entry: _ } => pass_ident(name, offset),
+        VarRef { name, st_entry: _ } => pass_ident(name, offset),
+        Literal { literal } => pass_literal(literal, offset),
+
+        Empty {} => {},
+    }
+}
+
+/// Passes a [unary operator](UnaOp) to update its range offsets.
+///
+/// # Arguments
+/// - `op`: The [`UnaOp`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+#[inline]
+fn pass_una_op(op: &mut UnaOp, offset: usize) {
+    use UnaOp::*;
+    match op {
+        Idx { range } | Not { range } | Neg { range } | Prio { range } => offset_range!(range, offset),
+    }
+}
+
+/// Passes a [binary operator](BinOp) to update its range offsets.
+///
+/// # Arguments
+/// - `op`: The [`BinOp`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+#[inline]
+fn pass_bin_op(op: &mut BinOp, offset: usize) {
+    use BinOp::*;
+    match op {
+        And { range }
+        | Or { range }
+        | Add { range }
+        | Sub { range }
+        | Mul { range }
+        | Div { range }
+        | Mod { range }
+        | Eq { range }
+        | Ne { range }
+        | Lt { range }
+        | Le { range }
+        | Gt { range }
+        | Ge { range } => offset_range!(range, offset),
+    }
+}
+
+/// Passes a [property expression](PropertyExpr) to update its range offsets.
+///
+/// # Arguments
+/// - `prop_expr`: The [`PropertyExpr`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+fn pass_prop_expr(prop_expr: &mut PropertyExpr, offset: usize) {
+    let PropertyExpr { name, value, range } = prop_expr;
+    pass_ident(name, offset);
+    pass_expr(value, offset);
+    offset_range!(range, offset);
+}
+
+/// Passes a [`Literal`] to update its range offsets.
+///
+/// # Arguments
+/// - `literal`: The [`Literal`] to traverse.
+/// - `offset`: The offset (in lines) to which to fix the node.
+#[inline]
+fn pass_literal(literal: &mut Literal, offset: usize) {
+    use Literal::*;
+    match literal {
+        Null { range }
+        | Boolean { value: _, range }
+        | Integer { value: _, range }
+        | Real { value: _, range }
+        | String { value: _, range }
+        | Semver { value: _, range }
+        | Void { range } => offset_range!(range, offset),
+    }
+}
+
+
+
+
+
+/***** LIBRARY *****/
+/// Fixes offsets in the AST to be relative to the entire source instead of just this snippet.
+///
+/// # Arguments
+/// - `root`: The root node of the tree on which this compiler pass will be done.
+/// - `state`: The [`CompileState`] containing the offset to offset with.
+///
+/// # Returns
+/// The same nodes as went in, but now with annotation statements translated to annotations on structs.
+///
+/// # Errors
+/// This pass cannot error.
+#[inline]
+pub fn do_traversal(mut root: Program, state: &CompileState) -> Result<Program, Vec<AstError>> {
+    pass_block(&mut root.block, state.offset);
+    Ok(root)
+}

--- a/brane-ast/src/traversals/print/ast.rs
+++ b/brane-ast/src/traversals/print/ast.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    31 Aug 2022, 09:25:11
 //  Last edited:
-//    07 Nov 2023, 14:41:50
+//    12 Dec 2023, 16:00:13
 //  Auto updated?
 //    Yes
 //
@@ -182,11 +182,11 @@ fn pass_edges(
         // Match on it
         use Edge::*;
         match node {
-            Node { task, locs, at, input, result, next } => {
+            Node { task, locs, at, input, result, metadata, next } => {
                 // Write the Node as a task call
                 writeln!(
                     writer,
-                    "{} {}Node({}){}{}{}",
+                    "{} {}Node({}){}{}{}{}",
                     line_number!(i),
                     indent!(indent),
                     match &table.task(*task) {
@@ -216,6 +216,23 @@ fn pass_edges(
                                 "''".into()
                             },
                             if let Some(name) = result { format!("'{name}'") } else { "''".into() },
+                        )
+                    } else {
+                        String::new()
+                    },
+                    if !metadata.is_empty() {
+                        format!(
+                            " <{}>",
+                            metadata
+                                .iter()
+                                .map(|md| format!(
+                                    "#{}.{}{}",
+                                    if md.owner.contains(' ') { format!("\"{}\"", md.owner) } else { md.owner.clone() },
+                                    if md.tag.contains(' ') { format!("\"{}\"", md.tag) } else { md.tag.clone() },
+                                    if let Some(signature) = &md.signature { format!(" <{signature}>") } else { String::new() }
+                                ))
+                                .collect::<Vec<String>>()
+                                .join(",")
                         )
                     } else {
                         String::new()
@@ -503,15 +520,40 @@ fn pass_edge_instr(writer: &mut impl Write, instr: &EdgeInstr, table: &SymTable)
 ///
 /// # Errors
 /// This pass may error if we failed to write to the given writer.
-pub fn do_traversal(root: &Workflow, writer: impl Write) -> Result<(), Vec<Error>> {
-    let mut writer = writer;
+pub fn do_traversal(root: &Workflow, mut writer: impl Write) -> Result<(), Vec<Error>> {
+    let Workflow { table, metadata, graph, funcs } = root;
 
     if let Err(err) = writeln!(&mut writer, "Workflow {{") {
         return Err(vec![Error::WriteError { err }]);
     };
 
+    // Print parsed metadata
+    if !metadata.is_empty() {
+        for md in metadata.iter() {
+            if let Err(err) = writeln!(
+                &mut writer,
+                "{}#{}.{}{}",
+                indent!(INDENT_SIZE),
+                if md.owner.contains(' ') { format!("\"{}\"", md.owner) } else { md.owner.clone() },
+                if md.tag.contains(' ') { format!("\"{}\"", md.tag) } else { md.tag.clone() },
+                if let Some(signature) = &md.signature { format!(" <{signature}>") } else { String::new() }
+            ) {
+                return Err(vec![Error::WriteError { err }]);
+            };
+        }
+        if let Err(err) = writeln!(&mut writer) {
+            return Err(vec![Error::WriteError { err }]);
+        };
+        if let Err(err) = writeln!(&mut writer) {
+            return Err(vec![Error::WriteError { err }]);
+        };
+        if let Err(err) = writeln!(&mut writer) {
+            return Err(vec![Error::WriteError { err }]);
+        };
+    }
+
     // First up: print the workflow table
-    if let Err(err) = pass_table(&mut writer, &root.table, INDENT_SIZE) {
+    if let Err(err) = pass_table(&mut writer, table, INDENT_SIZE) {
         return Err(vec![Error::WriteError { err }]);
     };
     if !root.table.vars.is_empty()
@@ -535,19 +577,19 @@ pub fn do_traversal(root: &Workflow, writer: impl Write) -> Result<(), Vec<Error
     if let Err(err) = writeln!(&mut writer, "{}<Main>", indent!(INDENT_SIZE)) {
         return Err(vec![Error::WriteError { err }]);
     };
-    if let Err(err) = pass_edges(&mut writer, 0, &root.graph, &root.table, INDENT_SIZE, &mut HashSet::new()) {
+    if let Err(err) = pass_edges(&mut writer, 0, graph, table, INDENT_SIZE, &mut HashSet::new()) {
         return Err(vec![Error::WriteError { err }]);
     };
 
     // Print the functions
-    for (i, f) in root.funcs.iter() {
+    for (i, f) in funcs.iter() {
         if let Err(err) = writeln!(&mut writer) {
             return Err(vec![Error::WriteError { err }]);
         };
-        if let Err(err) = writeln!(&mut writer, "{}<Function {} ({})>", indent!(INDENT_SIZE), *i, root.table.funcs[*i].name) {
+        if let Err(err) = writeln!(&mut writer, "{}<Function {} ({})>", indent!(INDENT_SIZE), *i, table.funcs[*i].name) {
             return Err(vec![Error::WriteError { err }]);
         };
-        if let Err(err) = pass_edges(&mut writer, 0, f, &root.table, INDENT_SIZE, &mut HashSet::new()) {
+        if let Err(err) = pass_edges(&mut writer, 0, f, table, INDENT_SIZE, &mut HashSet::new()) {
             return Err(vec![Error::WriteError { err }]);
         };
     }

--- a/brane-ast/src/traversals/print/dsl.rs
+++ b/brane-ast/src/traversals/print/dsl.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    18 Aug 2022, 13:46:22
 //  Last edited:
-//    08 Dec 2023, 17:59:31
+//    12 Dec 2023, 14:57:30
 //  Auto updated?
 //    Yes
 //
@@ -503,7 +503,11 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     " <{}>",
                     metadata
                         .iter()
-                        .map(|tag| if tag.contains(' ') { format!("#\"{tag}\"") } else { format!("#{tag}") })
+                        .map(|md| format!(
+                            "#{}.{}",
+                            if md.owner.contains(' ') { format!("\"{}\"", md.owner) } else { md.owner.clone() },
+                            if md.tag.contains(' ') { format!("\"{}\"", md.tag) } else { md.tag.clone() }
+                        ))
                         .collect::<Vec<String>>()
                         .join(" ")
                 )?;
@@ -818,7 +822,15 @@ pub fn do_traversal(root: Program, mut writer: impl Write) -> Result<Program, Ve
     if let Err(err) = writeln!(
         &mut writer,
         "{}\n",
-        root.metadata.iter().map(|tag| if tag.contains(' ') { format!("#\"{tag}\"") } else { format!("#{tag}") }).collect::<Vec<String>>().join(" ")
+        root.metadata
+            .iter()
+            .map(|md| format!(
+                "#{}.{}",
+                if md.owner.contains(' ') { format!("\"{}\"", md.owner) } else { md.owner.clone() },
+                if md.tag.contains(' ') { format!("\"{}\"", md.tag) } else { md.tag.clone() }
+            ))
+            .collect::<Vec<String>>()
+            .join(" ")
     ) {
         return Err(vec![Error::WriteError { err }]);
     }

--- a/brane-ast/src/traversals/print/dsl.rs
+++ b/brane-ast/src/traversals/print/dsl.rs
@@ -1,21 +1,21 @@
 //  DSL.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    18 Aug 2022, 13:46:22
 //  Last edited:
-//    23 Dec 2022, 16:08:34
+//    08 Dec 2023, 09:40:08
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Prints the `brane-dsl` AST in BraneScript-like Syntax.
-// 
+//
 
 use std::io::Write;
 
+use brane_dsl::ast::{self as dsl_ast, Attribute, Block, Expr, Identifier, Literal, Program, Property, PropertyExpr, Stmt};
 use brane_dsl::location::AllowedLocations;
-use brane_dsl::ast::{self as dsl_ast, Block, Expr, Identifier, Literal, Program, Property, PropertyExpr, Stmt};
 
 pub use crate::errors::AstError as Error;
 
@@ -27,6 +27,7 @@ pub mod tests {
     use brane_shr::utilities::{create_data_index, create_package_index, test_on_dsl_files};
     use specifications::data::DataIndex;
     use specifications::package::PackageIndex;
+
     use super::*;
     use crate::{compile_program_to, CompileResult, CompileStage};
 
@@ -40,7 +41,7 @@ pub mod tests {
 
             // Load the package index
             let pindex: PackageIndex = create_package_index();
-            let dindex: DataIndex    = create_data_index();
+            let dindex: DataIndex = create_data_index();
 
             // Run up to this traversal
             let program: Program = match compile_program_to(code.as_bytes(), &pindex, &dindex, &ParserOptions::bscript(), CompileStage::None) {
@@ -55,7 +56,7 @@ pub mod tests {
                     // Print the error
                     err.prettyprint(path.to_string_lossy(), &code);
                     panic!("Failed to parse file (see output above)");
-                }
+                },
                 CompileResult::Err(errs) => {
                     // Print the errors
                     for e in errs {
@@ -64,7 +65,9 @@ pub mod tests {
                     panic!("Failed to parse file (see output above)");
                 },
 
-                _ => { unreachable!(); },
+                _ => {
+                    unreachable!();
+                },
             };
 
             // Now print the tree
@@ -100,32 +103,43 @@ const INDENT_SIZE: usize = 4;
 
 /***** TRAVERSAL FUNCTIONS *****/
 /// Prints a Stmt node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `stmt`: The Stmt to traverse.
 /// - `indent`: The current base indent of all new lines to write.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io::Result<()> {
     // Match on the statement itself
     use Stmt::*;
     match stmt {
-        Block{ block } => {
+        /* TODO */
+        Block { block, attrs } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Pass over the block instead, but do print the indentation first.
             write!(writer, "{}", indent!(indent))?;
             pass_block(writer, block, indent)?;
             writeln!(writer)?;
         },
 
-        Import { name, version, .. } => {
+        Import { name, version, st_funcs: _, st_classes: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print as an import statement
             write!(writer, "{}import ", indent!(indent))?;
             // Print the identifier
             pass_identifier(writer, name)?;
             // Print the version, optionally
-            if let Literal::Semver{ range, .. } = &version {
+            if let Literal::Semver { range, .. } = &version {
                 if range.is_some() {
                     write!(writer, "[")?;
                     pass_literal(writer, version)?;
@@ -137,7 +151,12 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             // Do newline
             writeln!(writer)?;
         },
-        FuncDef{ ident, params, code, .. } => {
+        FuncDef { ident, params, code, st_entry: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the 'func' prefix
             write!(writer, "{}func ", indent!(indent))?;
             // Print the identifier
@@ -146,8 +165,11 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             write!(writer, "(")?;
             let mut first = true;
             for p in params {
-                if first { first = false; }
-                else { write!(writer, ", ")?; }
+                if first {
+                    first = false;
+                } else {
+                    write!(writer, ", ")?;
+                }
                 pass_identifier(writer, p)?;
             }
             // Print the block
@@ -155,7 +177,12 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             pass_block(writer, code, indent)?;
             writeln!(writer)?;
         },
-        ClassDef{ ident, props, methods, .. } => {
+        ClassDef { ident, props, methods, st_entry: _, symbol_table: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the 'class' prefix
             write!(writer, "{}class ", indent!(indent))?;
             // Print the identifier
@@ -168,7 +195,9 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
                 pass_property(writer, p, largest_prop, indent + 3)?;
             }
             // Print a newline if any properties have been written
-            if !props.is_empty() { writeln!(writer)?; }
+            if !props.is_empty() {
+                writeln!(writer)?;
+            }
             // Print the methods
             for m in methods {
                 pass_stmt(writer, m, indent + 3)?;
@@ -176,7 +205,12 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             // Finally, print the closing bracket
             writeln!(writer, "{}}}", indent!(indent))?;
         },
-        Return{ expr, .. } => {
+        Return { expr, data_type: _, output: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the return
             write!(writer, "{}return", indent!(indent))?;
             // If there is an expression, print it
@@ -187,8 +221,13 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             // Print the semicolon
             writeln!(writer, ";")?;
         },
-    
-        If{ cond, consequent, alternative, .. } => {
+
+        If { cond, consequent, alternative, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the if first + its condition
             write!(writer, "{}if (", indent!(indent))?;
             pass_expr(writer, cond, indent)?;
@@ -202,7 +241,12 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             }
             writeln!(writer)?;
         },
-        For{ initializer, condition, increment, consequent, .. } => {
+        For { initializer, condition, increment, consequent, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the three for parts
             write!(writer, "{}for (", indent!(indent))?;
             pass_stmt(writer, initializer, indent)?;
@@ -215,7 +259,12 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             pass_block(writer, consequent, indent)?;
             writeln!(writer)?;
         },
-        While{ condition, consequent, .. } => {
+        While { condition, consequent, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the while + its condition
             write!(writer, "{}while (", indent!(indent))?;
             pass_expr(writer, condition, indent)?;
@@ -224,16 +273,12 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             pass_block(writer, consequent, indent)?;
             writeln!(writer)?;
         },
-        On{ location, block, .. } => {
-            // Print the on + the location
-            write!(writer, "{}on ", indent!(indent))?;
-            pass_expr(writer, location, indent)?;
-            // Print the block
-            write!(writer, " ")?;
-            pass_block(writer, block, indent)?;
-            writeln!(writer)?;  
-        },
-        Parallel{ result, blocks, .. } => {
+        Parallel { result, blocks, merge: _, st_entry: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // If there is a result, parse that first
             write!(writer, "{}", indent!(indent))?;
             if let Some(result) = result {
@@ -245,12 +290,20 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             writeln!(writer, "parallel [")?;
             // Print the blocks
             for b in blocks {
-                pass_stmt(writer, b, indent + 3)?;
+                // Pass over the block instead, but do print the indentation first.
+                write!(writer, "{}", indent!(indent + INDENT_SIZE))?;
+                pass_block(writer, b, indent)?;
+                writeln!(writer)?;
             }
             writeln!(writer, "{}]", indent!(indent))?;
         },
 
-        LetAssign{ name, value, .. } => {
+        LetAssign { name, value, st_entry: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the let thingy first + the name
             write!(writer, "{}let ", indent!(indent))?;
             pass_identifier(writer, name)?;
@@ -259,7 +312,12 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             pass_expr(writer, value, indent)?;
             writeln!(writer, ";")?;
         },
-        Assign{ name, value, .. } => {
+        Assign { name, value, st_entry: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Just print the identifier
             write!(writer, "{}", indent!(indent))?;
             pass_identifier(writer, name)?;
@@ -268,27 +326,60 @@ pub fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io
             pass_expr(writer, value, indent)?;
             writeln!(writer, ";")?;
         },
-        Expr{ expr, .. } => {
+        Expr { expr, data_type: _, attrs, range: _ } => {
+            // Print the attributes
+            for attr in attrs {
+                pass_attr(writer, attr, false, indent)?;
+            }
+
             // Print the expression + semicolon
             write!(writer, "{}", indent!(indent))?;
             pass_expr(writer, expr, indent)?;
             writeln!(writer, ";")?;
         },
 
-        Empty{} => {},
+        Empty {} => {},
     }
 
     // Done
     Ok(())
 }
 
+/// Prints an attribute.
+///
+/// # Arguments
+/// - `writer`: The [`Write`]r to write to.
+/// - `attr`: The [`Attribute`] to traverse.
+/// - `is_inner`: If true, prints as an inner attribute (i.e., `#![...]` instead of `#[...]`).
+/// - `indent`: The current base indentation of all new lines to write.
+///
+/// # Errors
+/// This function may error if we failed to write to `writer`.
+pub fn pass_attr(writer: &mut impl Write, attr: &Attribute, is_inner: bool, indent: usize) -> std::io::Result<()> {
+    // Print the preceding tokens
+    write!(writer, "{}#{}[", indent!(indent), if is_inner { "!" } else { "" })?;
+    // Print the attribute value
+    match attr {
+        Attribute::KeyPair { key, value, range: _ } => {
+            pass_identifier(writer, key)?;
+            write!(writer, " = ")?;
+            pass_literal(writer, value)?;
+        },
+    }
+    // Print the suffixing tokens
+    writeln!(writer, "]")?;
+
+    // Done!
+    Ok(())
+}
+
 /// Prints a Block node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `block`: The Block to traverse.
 /// - `indent`: The current base indent of all new lines to write.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 pub fn pass_block(writer: &mut impl Write, block: &Block, indent: usize) -> std::io::Result<()> {
@@ -306,13 +397,13 @@ pub fn pass_block(writer: &mut impl Write, block: &Block, indent: usize) -> std:
 }
 
 /// Prints an Identifier node.
-/// 
+///
 /// This will always be printed as a non-statement, so no indentation required.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `identifier`: The Identifier to traverse.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 pub fn pass_identifier(writer: &mut impl Write, identifier: &Identifier) -> std::io::Result<()> {
@@ -321,13 +412,13 @@ pub fn pass_identifier(writer: &mut impl Write, identifier: &Identifier) -> std:
 }
 
 /// Prints a Property node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `prop`: The Property to traverse.
 /// - `largest_prop`: The longest property name. It will auto-pad all names to this length to make a nice list.
 /// - `indent`: The current base indent of all new lines to write.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 pub fn pass_property(writer: &mut impl Write, prop: &Property, largest_prop: usize, indent: usize) -> std::io::Result<()> {
@@ -342,19 +433,19 @@ pub fn pass_property(writer: &mut impl Write, prop: &Property, largest_prop: usi
 }
 
 /// Prints an Expr node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `expr`: The Expr to traverse.
 /// - `indent`: The current base indent of all new lines to write.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io::Result<()> {
     // Match the expression
     use Expr::*;
     match expr {
-        Cast{ expr, target, .. } => {
+        Cast { expr, target, .. } => {
             // Print the cast operator
             write!(writer, "(({target}) ")?;
             // Print the expression
@@ -363,15 +454,18 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
             write!(writer, ")")?;
         },
 
-        Call{ expr, args, locations, .. } => {
+        Call { expr, args, locations, .. } => {
             // Print the identifying expression
             pass_expr(writer, expr, indent)?;
             // Print the arguments
             write!(writer, "(")?;
             let mut first = true;
             for a in args {
-                if first { first = false; }
-                else { write!(writer, ", ")?; }
+                if first {
+                    first = false;
+                } else {
+                    write!(writer, ", ")?;
+                }
                 pass_expr(writer, a, indent)?;
             }
             // Print the closing bracket
@@ -382,18 +476,21 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                 write!(writer, " @[{}]", locs.iter().map(|l| l.into()).collect::<Vec<String>>().join(","))?;
             }
         },
-        Array{ values, .. } => {
+        Array { values, .. } => {
             // Print the values wrapped in '[]'
             write!(writer, "[")?;
             let mut first = true;
             for v in values {
-                if first { first = false; }
-                else { write!(writer, ", ")?; }
+                if first {
+                    first = false;
+                } else {
+                    write!(writer, ", ")?;
+                }
                 pass_expr(writer, v, indent)?;
             }
             write!(writer, "]")?;
         },
-        ArrayIndex{ array, index, .. } => {
+        ArrayIndex { array, index, .. } => {
             // Print the array first
             pass_expr(writer, array, indent)?;
             // Print the index expression wrapped in '[]'
@@ -401,40 +498,43 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
             pass_expr(writer, index, indent)?;
             write!(writer, "]")?;
         },
-        Pattern{ exprs, .. } => {
+        Pattern { exprs, .. } => {
             // We use ad-hoc syntax for now
             write!(writer, "Pattern<")?;
             let mut first = true;
             for e in exprs {
-                if first { first = false; }
-                else { write!(writer, ", ")?; }
+                if first {
+                    first = false;
+                } else {
+                    write!(writer, ", ")?;
+                }
                 pass_expr(writer, e, indent)?;
             }
             write!(writer, ">")?;
         },
 
-        UnaOp{ op, expr, .. } => {
+        UnaOp { op, expr, .. } => {
             // How to print exact is operator-determined
             match op {
-                dsl_ast::UnaOp::Idx{ .. } => {
+                dsl_ast::UnaOp::Idx { .. } => {
                     // Print the expr expression wrapped in '[]'
                     write!(writer, "[")?;
                     pass_expr(writer, expr, indent)?;
                     write!(writer, "]")?;
                 },
-                dsl_ast::UnaOp::Not{ .. } => {
+                dsl_ast::UnaOp::Not { .. } => {
                     // Print the logical negation, then the expression
                     write!(writer, "(!")?;
                     pass_expr(writer, expr, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::UnaOp::Neg{ .. } => {
+                dsl_ast::UnaOp::Neg { .. } => {
                     // Print the mathmatical negation, then the expression
                     write!(writer, "(-")?;
                     pass_expr(writer, expr, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::UnaOp::Prio{ .. } => {
+                dsl_ast::UnaOp::Prio { .. } => {
                     // Print simply in between brackets
                     write!(writer, "(")?;
                     pass_expr(writer, expr, indent)?;
@@ -442,10 +542,10 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                 },
             }
         },
-        BinOp{ op, lhs, rhs, .. } => {
+        BinOp { op, lhs, rhs, .. } => {
             // How to print exact is operator-determined
             match op {
-                dsl_ast::BinOp::And{ .. } => {
+                dsl_ast::BinOp::And { .. } => {
                     // Print lhs && rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -453,7 +553,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Or{ .. } => {
+                dsl_ast::BinOp::Or { .. } => {
                     // Print lhs || rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -462,7 +562,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     write!(writer, ")")?;
                 },
 
-                dsl_ast::BinOp::Add{ .. } => {
+                dsl_ast::BinOp::Add { .. } => {
                     // Print lhs + rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -470,7 +570,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Sub{ .. } => {
+                dsl_ast::BinOp::Sub { .. } => {
                     // Print lhs - rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -478,7 +578,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Mul{ .. } => {
+                dsl_ast::BinOp::Mul { .. } => {
                     // Print lhs * rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -486,7 +586,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Div{ .. } => {
+                dsl_ast::BinOp::Div { .. } => {
                     // Print lhs / rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -494,7 +594,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Mod{ .. } => {
+                dsl_ast::BinOp::Mod { .. } => {
                     // Print lhs % rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -503,7 +603,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     write!(writer, ")")?;
                 },
 
-                dsl_ast::BinOp::Eq{ .. } => {
+                dsl_ast::BinOp::Eq { .. } => {
                     // Print lhs == rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -511,7 +611,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Ne{ .. } => {
+                dsl_ast::BinOp::Ne { .. } => {
                     // Print lhs != rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -519,7 +619,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Lt{ .. } => {
+                dsl_ast::BinOp::Lt { .. } => {
                     // Print lhs < rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -527,7 +627,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Le{ .. } => {
+                dsl_ast::BinOp::Le { .. } => {
                     // Print lhs <= rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -535,7 +635,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Gt{ .. } => {
+                dsl_ast::BinOp::Gt { .. } => {
                     // Print lhs > rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -543,7 +643,7 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-                dsl_ast::BinOp::Ge{ .. } => {
+                dsl_ast::BinOp::Ge { .. } => {
                     // Print lhs >= rhs
                     write!(writer, "(")?;
                     pass_expr(writer, lhs, indent)?;
@@ -551,7 +651,6 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                     pass_expr(writer, rhs, indent)?;
                     write!(writer, ")")?;
                 },
-
                 // dsl_ast::BinOp::Proj{ .. } => {
                 //     // Print lhs.rhs
                 //     write!(writer, "(")?;
@@ -562,14 +661,14 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
                 // },
             }
         },
-        Proj{ lhs, rhs, .. } => {
+        Proj { lhs, rhs, .. } => {
             // Print lhs.rhs
             pass_expr(writer, lhs, indent)?;
             write!(writer, ".")?;
             pass_expr(writer, rhs, indent)?;
         },
 
-        Instance{ name, properties, .. } => {
+        Instance { name, properties, .. } => {
             // Print 'new Name'
             write!(writer, "new ")?;
             pass_identifier(writer, name)?;
@@ -583,20 +682,20 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
             // Print the closing thingy
             write!(writer, "{}}}", indent!(indent))?;
         },
-        VarRef{ name, .. } => {
+        VarRef { name, .. } => {
             // Print the identifier
             pass_identifier(writer, name)?;
         },
-        Identifier{ name, .. } => {
+        Identifier { name, .. } => {
             // Print the identifier
             pass_identifier(writer, name)?;
         },
-        Literal{ literal } => {
+        Literal { literal } => {
             // Print the literal
             pass_literal(writer, literal)?;
         },
 
-        Empty{} => {},
+        Empty {} => {},
     }
 
     // Done
@@ -604,12 +703,12 @@ pub fn pass_expr(writer: &mut impl Write, expr: &Expr, indent: usize) -> std::io
 }
 
 /// Prints a PropertyExpr node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `prop`: The PropertyExpr to traverse.
 /// - `largest_prop`: The longest property name. It will auto-pad all names to this length to make a nice list.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 pub fn pass_property_expr(writer: &mut impl Write, prop: &PropertyExpr, largest_prop: usize, indent: usize) -> std::io::Result<()> {
@@ -627,36 +726,36 @@ pub fn pass_property_expr(writer: &mut impl Write, prop: &PropertyExpr, largest_
 }
 
 /// Prints a Literal node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `literal`: The Literal to traverse.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 pub fn pass_literal(writer: &mut impl Write, literal: &Literal) -> std::io::Result<()> {
     // Match on the exact literal kind
     use Literal::*;
     match literal {
-        Null{ .. } => {
+        Null { .. } => {
             write!(writer, "null")?;
         },
-        Boolean{ value, .. } => {
+        Boolean { value, .. } => {
             write!(writer, "{}", if *value { "true" } else { "false" })?;
         },
-        Integer{ value, .. } => {
+        Integer { value, .. } => {
             write!(writer, "{}", *value)?;
         },
-        Real{ value, .. } => {
+        Real { value, .. } => {
             write!(writer, "{}", *value)?;
         },
-        String{ value, .. } => {
+        String { value, .. } => {
             write!(writer, "\"{value}\"")?;
         },
-        Semver{ value, .. } => {
+        Semver { value, .. } => {
             write!(writer, "{value}")?;
-        }
-        Void{ .. } => {
+        },
+        Void { .. } => {
             write!(writer, "<void>")?;
         },
     }
@@ -671,14 +770,14 @@ pub fn pass_literal(writer: &mut impl Write, literal: &Literal) -> std::io::Resu
 
 /***** LIBRARY *****/
 /// Starts printing the root of the AST (i.e., a series of statements).
-/// 
+///
 /// # Arguments
 /// - `root`: The root node of the tree on which this compiler pass will be done.
 /// - `writer`: The `Write`r to write to.
-/// 
+///
 /// # Returns
 /// The same root node as went in (since this compiler pass performs no transformations on the tree).
-/// 
+///
 /// # Errors
 /// This pass doesn't really error, but is here for convention purposes.
 pub fn do_traversal(root: Program, writer: impl Write) -> Result<Program, Vec<Error>> {
@@ -687,7 +786,7 @@ pub fn do_traversal(root: Program, writer: impl Write) -> Result<Program, Vec<Er
     // Iterate over all statements and run the appropriate match
     for s in root.block.stmts.iter() {
         if let Err(err) = pass_stmt(&mut writer, s, 0) {
-            return Err(vec![ Error::WriteError{ err } ]);
+            return Err(vec![Error::WriteError { err }]);
         }
     }
 

--- a/brane-ast/src/traversals/print/symbol_tables.rs
+++ b/brane-ast/src/traversals/print/symbol_tables.rs
@@ -1,25 +1,25 @@
 //  SYMBOL TABLES.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    19 Aug 2022, 12:43:19
 //  Last edited:
-//    23 Dec 2022, 16:18:25
+//    08 Dec 2023, 11:06:12
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Implements a traversal that prints all symbol tables neatly for a
 //!   given program.
-// 
+//
 
 use std::cell::{Ref, RefCell};
 use std::io::Write;
 use std::rc::Rc;
 
-use brane_dsl::SymbolTable;
-use brane_dsl::symbol_table::{ClassEntry, FunctionEntry, VarEntry};
 use brane_dsl::ast::{Block, Program, Stmt};
+use brane_dsl::symbol_table::{ClassEntry, FunctionEntry, VarEntry};
+use brane_dsl::SymbolTable;
 
 pub use crate::errors::AstError as Error;
 
@@ -46,39 +46,39 @@ const INDENT_SIZE: usize = 4;
 
 /***** TRAVERSAL FUNCTIONS *****/
 /// Prints a Stmt node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `stmt`: The Stmt to traverse.
 /// - `indent`: The current base indent of all new lines to write.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io::Result<()> {
     // Match on the statement itself
     use Stmt::*;
     match stmt {
-        Block{ block } => {
+        Block { block } => {
             // Simply print this one's symbol table
             write!(writer, "{}__nested_block: ", indent!(indent))?;
             pass_block(writer, block, indent)?;
             writeln!(writer)?;
         },
 
-        FuncDef{ ident, code, .. } => {
+        FuncDef { ident, code, .. } => {
             // Print the code block's symbol table
             write!(writer, "{}Function '{}': ", indent!(indent), ident.value)?;
             pass_block(writer, code, indent)?;
             writeln!(writer)?;
         },
-        ClassDef{ methods, .. } => {
+        ClassDef { methods, .. } => {
             // Recurse into the methods
             for m in methods.iter() {
                 pass_stmt(writer, m, indent)?;
             }
         },
-    
-        If{ consequent, alternative, .. } => {
+
+        If { consequent, alternative, .. } => {
             // Print the symbol tables of the consequent and (optionally) the alternative
             write!(writer, "{}If ", indent!(indent))?;
             pass_block(writer, consequent, indent)?;
@@ -88,35 +88,31 @@ fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io::Re
             }
             writeln!(writer)?;
         },
-        For{ consequent, .. } => {
+        For { consequent, .. } => {
             // Print the symbol table of the consequent
             write!(writer, "{}For ", indent!(indent))?;
             pass_block(writer, consequent, indent)?;
             writeln!(writer)?;
         },
-        While{ consequent, .. } => {
+        While { consequent, .. } => {
             // Print the block
             write!(writer, "{}While ", indent!(indent))?;
             pass_block(writer, consequent, indent)?;
             writeln!(writer)?;
         },
-        On{ block, .. } => {
-            // Print the block
-            write!(writer, "{}On ", indent!(indent))?;
-            pass_block(writer, block, indent)?;
-            writeln!(writer)?;
-        },
-        Parallel{ blocks, .. } => {
+        Parallel { blocks, .. } => {
             // Print the blocks
             writeln!(writer, "{}Parallel [", indent!(indent))?;
-            for b in blocks {
-                pass_stmt(writer, b, indent + 3)?;
+            for (i, b) in blocks.iter().enumerate() {
+                write!(writer, "{}__brach_{}: ", indent!(indent), i)?;
+                pass_block(writer, b, indent + 3)?;
+                writeln!(writer)?;
             }
             writeln!(writer, "{}]", indent!(indent))?;
         },
 
         // We don't care about the rest
-        _ => {}
+        _ => {},
     }
 
     // Done
@@ -124,12 +120,12 @@ fn pass_stmt(writer: &mut impl Write, stmt: &Stmt, indent: usize) -> std::io::Re
 }
 
 /// Prints a Block node.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `block`: The Block to traverse.
 /// - `indent`: The current base indent of all new lines to write.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 fn pass_block(writer: &mut impl Write, block: &Block, indent: usize) -> std::io::Result<()> {
@@ -139,7 +135,9 @@ fn pass_block(writer: &mut impl Write, block: &Block, indent: usize) -> std::io:
 
     // Now we print the following symbol tables with additional indentation
     let st: Ref<SymbolTable> = block.table.borrow();
-    if !block.stmts.is_empty() && (st.has_functions() || st.has_classes() || st.has_variables()) { writeln!(writer)?; }
+    if !block.stmts.is_empty() && (st.has_functions() || st.has_classes() || st.has_variables()) {
+        writeln!(writer)?;
+    }
     for stmt in block.stmts.iter() {
         pass_stmt(writer, stmt, indent + INDENT_SIZE)?;
     }
@@ -149,12 +147,12 @@ fn pass_block(writer: &mut impl Write, block: &Block, indent: usize) -> std::io:
 }
 
 /// Prints a SymbolTable.
-/// 
+///
 /// # Arguments
 /// - `writer`: The `Write`r to write to.
 /// - `symbol_table`: The SymbolTable to traverse.
 /// - `indent`: The current base indent of all new lines to write.
-/// 
+///
 /// # Returns
 /// Nothing, but does print it.
 fn pass_symbol_table(writer: &mut impl Write, symbol_table: &Rc<RefCell<SymbolTable>>, indent: usize) -> std::io::Result<()> {
@@ -164,7 +162,9 @@ fn pass_symbol_table(writer: &mut impl Write, symbol_table: &Rc<RefCell<SymbolTa
     // First, print all of its functions
     for (name, f) in st.functions() {
         let f: Ref<FunctionEntry> = f.borrow();
-        writeln!(writer, "{}{}func {}{}{}",
+        writeln!(
+            writer,
+            "{}{}func {}{}{}",
             indent!(indent),
             if f.index != usize::MAX { format!("{}) ", f.index) } else { String::new() },
             if let Some(pkg) = &f.package_name { format!("{pkg}::") } else { String::new() },
@@ -177,7 +177,9 @@ fn pass_symbol_table(writer: &mut impl Write, symbol_table: &Rc<RefCell<SymbolTa
         let c: Ref<ClassEntry> = c.borrow();
 
         // Print the class signature header
-        writeln!(writer, "{}{}class {}{} {{",
+        writeln!(
+            writer,
+            "{}{}class {}{} {{",
             indent!(indent),
             if c.index != usize::MAX { format!("{}) ", c.index) } else { String::new() },
             if let Some(pkg) = &c.package_name { format!("{pkg}::") } else { String::new() },
@@ -191,7 +193,14 @@ fn pass_symbol_table(writer: &mut impl Write, symbol_table: &Rc<RefCell<SymbolTa
     // Finally, print the variables
     for (name, v) in st.variables() {
         let v: Ref<VarEntry> = v.borrow();
-        writeln!(writer, "{}{}var {} : {},", indent!(indent), if v.index != usize::MAX { format!("{}) ", v.index) } else { String::new() }, name, v.data_type)?;
+        writeln!(
+            writer,
+            "{}{}var {} : {},",
+            indent!(indent),
+            if v.index != usize::MAX { format!("{}) ", v.index) } else { String::new() },
+            name,
+            v.data_type
+        )?;
     }
 
     // Done
@@ -204,23 +213,29 @@ fn pass_symbol_table(writer: &mut impl Write, symbol_table: &Rc<RefCell<SymbolTa
 
 /***** LIBRARY *****/
 /// Starts printing the root of the AST (i.e., a series of statements).
-/// 
+///
 /// # Arguments
 /// - `root`: The root node of the tree on which this compiler pass will be done.
 /// - `writer`: The `Write`r to write to.
-/// 
+///
 /// # Returns
 /// The same root node as went in (since this compiler pass performs no transformations on the tree).
-/// 
+///
 /// # Errors
 /// This pass generally doesn't error, but is here for convention purposes.
 pub fn do_traversal(root: Program, writer: impl Write) -> Result<Program, Vec<Error>> {
     let mut writer = writer;
 
     // Iterate over all statements and run the appropriate match
-    if let Err(err) = write!(&mut writer, "__root ")          { return Err(vec![ Error::WriteError { err } ]); };
-    if let Err(err) = pass_block(&mut writer, &root.block, 0) { return Err(vec![ Error::WriteError { err } ]); };
-    if let Err(err) = writeln!(&mut writer)                   { return Err(vec![ Error::WriteError { err } ]); };
+    if let Err(err) = write!(&mut writer, "__root ") {
+        return Err(vec![Error::WriteError { err }]);
+    };
+    if let Err(err) = pass_block(&mut writer, &root.block, 0) {
+        return Err(vec![Error::WriteError { err }]);
+    };
+    if let Err(err) = writeln!(&mut writer) {
+        return Err(vec![Error::WriteError { err }]);
+    };
 
     // Done
     Ok(root)

--- a/brane-ast/src/traversals/resolve.rs
+++ b/brane-ast/src/traversals/resolve.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    18 Aug 2022, 15:24:54
 //  Last edited:
-//    08 Dec 2023, 10:39:44
+//    12 Dec 2023, 17:13:11
 //  Auto updated?
 //    Yes
 //
@@ -17,7 +17,7 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use brane_dsl::ast::{Block, Expr, Identifier, Literal, Node, Program, Stmt};
+use brane_dsl::ast::{Block, Expr, Identifier, Node, Program, Stmt};
 use brane_dsl::data_type::{ClassSignature, FunctionSignature};
 use brane_dsl::spec::MergeStrategy;
 use brane_dsl::symbol_table::{ClassEntry, FunctionEntry, SymbolTableEntry, VarEntry};
@@ -96,21 +96,6 @@ pub mod tests {
 
 
 
-/***** HELPER MACROS *****/
-/// Applies an offset to the given TextRange if it is not none.
-macro_rules! offset_range {
-    ($range:expr, $offset:expr) => {
-        if $range.is_some() {
-            $range.start.line += $offset;
-            $range.end.line += $offset;
-        }
-    };
-}
-
-
-
-
-
 /***** HELPER FUNCTIONS ******/
 /// Defines the arguments of the given FuncDef in the given symbol table.
 ///
@@ -127,18 +112,11 @@ macro_rules! offset_range {
 /// This function may error if the given symbol table already existed.
 ///
 /// If such an error occurred, then it is added to the given `errors` list. Some arguments may be undefined in that case.
-fn define_func(
-    state: &CompileState,
-    entry: &mut FunctionEntry,
-    params: &mut [Identifier],
-    symbol_table: &Rc<RefCell<SymbolTable>>,
-    errors: &mut Vec<Error>,
-) {
+fn define_func(entry: &mut FunctionEntry, params: &mut [Identifier], symbol_table: &Rc<RefCell<SymbolTable>>, errors: &mut Vec<Error>) {
     // Iterate to add them
     {
         let mut st: RefMut<SymbolTable> = symbol_table.borrow_mut();
         for p in params.iter_mut() {
-            offset_range!(p.range, state.offset);
             match st.add_var(VarEntry::from_param(&p.value, &entry.name, p.range().clone())) {
                 Ok(e) => {
                     entry.params.push(e);
@@ -187,9 +165,6 @@ fn pass_block(
     parent: Option<Rc<RefCell<SymbolTable>>>,
     errors: &mut Vec<Error>,
 ) {
-    // Update the block's range
-    offset_range!(block.range, state.offset);
-
     // Set the parent for this block's symbol table
     {
         let mut st: RefMut<SymbolTable> = block.table.borrow_mut();
@@ -234,17 +209,12 @@ fn pass_stmt(
     // Match on the exact statement
     use Stmt::*;
     match stmt {
-        Block { block, .. } => {
+        Block { block } => {
             // Blocks require renewed evaluation
             pass_block(state, package_index, data_index, block, Some(symbol_table.clone()), errors);
         },
 
-        Import { ref mut name, version, ref mut st_funcs, ref mut st_classes, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(name.range, state.offset);
-            offset_range!(range, state.offset);
-            pass_literal(state, version);
-
+        Import { name, version, st_funcs, st_classes, attrs: _, range } => {
             // First: parse the version
             let semver: Version = match version.as_version() {
                 Ok(version) => version,
@@ -336,14 +306,10 @@ fn pass_stmt(
             *st_funcs = Some(funcs);
             *st_classes = Some(classes);
         },
-        FuncDef { ref mut ident, ref mut params, code, ref mut st_entry, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(ident.range, state.offset);
-            offset_range!(range, state.offset);
-
+        FuncDef { ident, params, code, st_entry, attrs: _, range } => {
             // Prepare the entry
             let mut entry: FunctionEntry = FunctionEntry::from_def(&ident.value, range.clone());
-            define_func(state, &mut entry, params, &code.table, errors);
+            define_func(&mut entry, params, &code.table, errors);
 
             // We can then add the function definition to the given symbol table
             {
@@ -362,11 +328,7 @@ fn pass_stmt(
             // Now go and populate the rest of its symbol table in the function body.
             pass_block(state, package_index, data_index, code, Some(symbol_table.clone()), errors);
         },
-        ClassDef { ref mut ident, ref mut props, ref mut methods, ref mut st_entry, symbol_table: c_symbol_table, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(ident.range, state.offset);
-            offset_range!(range, state.offset);
-
+        ClassDef { ident, props, methods, st_entry, symbol_table: c_symbol_table, attrs: _, range } => {
             // First, we generate the class entry as complete as we can
             // 1. Prepare the class' symbol table
             {
@@ -378,9 +340,6 @@ fn pass_stmt(
                 // Add each of the properties in this class
                 let st: Ref<SymbolTable> = symbol_table.borrow();
                 for p in props.iter_mut() {
-                    offset_range!(p.range, state.offset);
-                    offset_range!(p.name.range, state.offset);
-
                     // Check if the data type exists if it references another class
                     if let DataType::Class(c_name) = &p.data_type {
                         if st.get_class(c_name).is_none() {
@@ -403,17 +362,7 @@ fn pass_stmt(
 
                 // Add definitions for each of its functions
                 for m in methods.iter_mut() {
-                    if let Stmt::FuncDef {
-                        ident: m_ident,
-                        params: m_params,
-                        code: m_code,
-                        st_entry: ref mut m_st_entry,
-                        range: ref mut m_range,
-                        ..
-                    } = &mut **m
-                    {
-                        offset_range!(m_range, state.offset);
-
+                    if let Stmt::FuncDef { ident: m_ident, params: m_params, code: m_code, st_entry: m_st_entry, range: m_range, .. } = &mut **m {
                         // First, check if its name does not overlap with a property (i.e., we want one namespace for a class)
                         if let Some(p) = cst.get_var(&m_ident.value) {
                             errors.push(Error::DuplicateMethodAndProperty {
@@ -445,7 +394,7 @@ fn pass_stmt(
 
                         // If it passes those checks, we create an entry for it
                         let mut entry: FunctionEntry = FunctionEntry::from_method(m_ident.value.clone(), &ident.value, m_range.clone());
-                        define_func(state, &mut entry, m_params, &m_code.table, errors);
+                        define_func(&mut entry, m_params, &m_code.table, errors);
                         m_code.table.borrow_mut().parent = Some(symbol_table.clone());
 
                         // Add it to the class' table
@@ -491,20 +440,14 @@ fn pass_stmt(
 
             // Done; we added a full class entry and recursed
         },
-        Return { expr, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(range, state.offset);
-
+        Return { expr, data_type: _, output: _, attrs: _, range: _ } => {
             // Traverse the expression to resolve any references (by the time we reach it, the symbol table should already be sufficiently populated)
             if let Some(expr) = expr {
                 pass_expr(state, data_index, expr, symbol_table, errors);
             }
         },
 
-        If { cond, consequent, alternative, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(range, state.offset);
-
+        If { cond, consequent, alternative, attrs: _, range: _ } => {
             // Recurse into the condition
             pass_expr(state, data_index, cond, symbol_table, errors);
 
@@ -514,10 +457,7 @@ fn pass_stmt(
                 pass_block(state, package_index, data_index, alternative, Some(symbol_table.clone()), errors);
             }
         },
-        For { initializer, condition, increment, consequent, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(range, state.offset);
-
+        For { initializer, condition, increment, consequent, attrs: _, range: _ } => {
             // Set the parent for the nested block's symbol table
             {
                 let mut st: RefMut<SymbolTable> = consequent.table.borrow_mut();
@@ -534,22 +474,15 @@ fn pass_stmt(
                 pass_stmt(state, package_index, data_index, s, &consequent.table, errors);
             }
         },
-        While { condition, consequent, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(range, state.offset);
-
+        While { condition, consequent, attrs: _, range: _ } => {
             // Recurse into the while-part first
             pass_expr(state, data_index, condition, symbol_table, errors);
             // Recurse into the block
             pass_block(state, package_index, data_index, consequent, Some(symbol_table.clone()), errors);
         },
-        Parallel { ref mut result, blocks, ref mut merge, ref mut st_entry, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(range, state.offset);
-
+        Parallel { result, blocks, merge, st_entry, attrs: _, range } => {
             // First, very silly, but double-check the merge is parseable
             if let Some(merge) = merge {
-                offset_range!(merge.range, state.offset);
                 if let MergeStrategy::None = MergeStrategy::from(&merge.value) {
                     errors.push(Error::UnknownMergeStrategy { raw: merge.value.clone(), range: merge.range.clone() });
                 }
@@ -562,8 +495,6 @@ fn pass_stmt(
 
             // If present, declare the result as last
             if let Some(result) = result {
-                offset_range!(result.range, state.offset);
-
                 // Attempt to declare the identifier
                 let mut st: RefMut<SymbolTable> = symbol_table.borrow_mut();
                 match st.add_var(VarEntry::from_def(&result.value, range.clone())) {
@@ -577,11 +508,7 @@ fn pass_stmt(
             }
         },
 
-        LetAssign { ref mut name, value, ref mut st_entry, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(name.range, state.offset);
-            offset_range!(range, state.offset);
-
+        LetAssign { name, value, st_entry, attrs: _, range } => {
             // Recursestate,  into the expression to resolve any reference there
             pass_expr(state, data_index, value, symbol_table, errors);
 
@@ -596,11 +523,7 @@ fn pass_stmt(
                 },
             }
         },
-        Assign { ref mut name, value, ref mut st_entry, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(name.range, state.offset);
-            offset_range!(range, state.offset);
-
+        Assign { name, value, st_entry, attrs: _, range: _ } => {
             // Recurse into the expression to resolve any reference there
             pass_expr(state, data_index, value, symbol_table, errors);
 
@@ -615,10 +538,7 @@ fn pass_stmt(
                 },
             }
         },
-        Expr { expr, ref mut range, .. } => {
-            // Update the block's range
-            offset_range!(range, state.offset);
-
+        Expr { expr, data_type: _, attrs: _, range: _ } => {
             // Simply recurse
             pass_expr(state, data_index, expr, symbol_table, errors);
         },
@@ -651,21 +571,15 @@ fn pass_expr(state: &CompileState, data_index: &DataIndex, expr: &mut Expr, symb
     // Match on the exact expression
     use Expr::*;
     match expr {
-        Cast { expr, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        Cast { expr, target: _, range: _ } => {
             pass_expr(state, data_index, expr, symbol_table, errors);
         },
 
-        Call { expr, args, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        Call { expr, args, st_entry: _, locations: _, input: _, result: _, metadata: _, range: _ } => {
             // Simply recurse the called expression
             pass_expr(state, data_index, expr, symbol_table, errors);
             // If it's an identifier, set its entry to which function it is referring
-            if let brane_dsl::ast::Expr::Identifier { name, ref mut st_entry, .. } = &mut **expr {
+            if let brane_dsl::ast::Expr::Identifier { name, st_entry, .. } = &mut **expr {
                 // Search the name
                 let st: Ref<SymbolTable> = symbol_table.borrow();
                 match st.get_func(&name.value) {
@@ -693,52 +607,34 @@ fn pass_expr(state: &CompileState, data_index: &DataIndex, expr: &mut Expr, symb
                 pass_expr(state, data_index, a, symbol_table, errors);
             }
         },
-        Array { values, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        Array { values, data_type: _, range: _ } => {
             // Simply recurse
             for v in values {
                 pass_expr(state, data_index, v, symbol_table, errors);
             }
         },
-        ArrayIndex { array, index, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        ArrayIndex { array, index, data_type: _, range: _ } => {
             // Simply recurse
             pass_expr(state, data_index, array, symbol_table, errors);
             pass_expr(state, data_index, index, symbol_table, errors);
         },
-        Pattern { exprs, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        Pattern { exprs, range: _ } => {
             // Simply recurse
             for e in exprs {
                 pass_expr(state, data_index, e, symbol_table, errors);
             }
         },
 
-        UnaOp { expr, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        UnaOp { op: _, expr, range: _ } => {
             // Simply recurse
             pass_expr(state, data_index, expr, symbol_table, errors);
         },
-        BinOp { lhs, rhs, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        BinOp { op: _, lhs, rhs, range: _ } => {
             // Simply recurse
             pass_expr(state, data_index, lhs, symbol_table, errors);
             pass_expr(state, data_index, rhs, symbol_table, errors);
         },
-        Proj { lhs, rhs, ref mut st_entry, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(range, state.offset);
-
+        Proj { lhs, rhs, st_entry, range: _ } => {
             // By design, the lhs is only Expr::VarRef or Expr::Proj
             // The rhs is only Expr::Identifier
 
@@ -847,11 +743,7 @@ fn pass_expr(state: &CompileState, data_index: &DataIndex, expr: &mut Expr, symb
             }
         },
 
-        Instance { ref mut name, ref mut properties, ref mut st_entry, ref mut range, .. } => {
-            // Update the expr's range
-            offset_range!(name.range, state.offset);
-            offset_range!(range, state.offset);
-
+        Instance { name, properties, st_entry, range: _ } => {
             // First, attempt to resolve the class name
             {
                 let st: Ref<SymbolTable> = symbol_table.borrow();
@@ -869,9 +761,6 @@ fn pass_expr(state: &CompileState, data_index: &DataIndex, expr: &mut Expr, symb
             // Next, iterate over the properties to resolve those expressions
             let entry: Ref<ClassEntry> = st_entry.as_ref().unwrap().borrow();
             for p in properties.iter_mut() {
-                offset_range!(p.range, state.offset);
-                offset_range!(p.name.range, state.offset);
-
                 // But first, double-check this property is actually present in the type (since this type resolving does not require extra type checking)
                 if entry.symbol_table.borrow().get_var(&p.name.value).is_none() {
                     errors.push(Error::UnknownField { class_name: name.value.clone(), name: p.name.value.clone(), range: p.name.range().clone() });
@@ -912,12 +801,12 @@ fn pass_expr(state: &CompileState, data_index: &DataIndex, expr: &mut Expr, symb
                 // With the dataset resolved, we rest easy
             }
         },
-        Identifier { ref mut name, .. } => {
+        Identifier { name, st_entry: _ } => {
             // Update the expr's range
             name.range.start.line += state.offset;
             name.range.end.line += state.offset;
         },
-        VarRef { ref mut name, ref mut st_entry, .. } => {
+        VarRef { name, st_entry } => {
             // Update the expr's range
             name.range.start.line += state.offset;
             name.range.end.line += state.offset;
@@ -933,48 +822,12 @@ fn pass_expr(state: &CompileState, data_index: &DataIndex, expr: &mut Expr, symb
                 },
             }
         },
-        Literal { ref mut literal } => {
-            pass_literal(state, literal);
-        },
 
         // The rest is irrelevant for resolving the symbol tables
-        _ => {},
+        Literal { literal: _ } | Empty {} => {},
     }
 
     // We're done here
-}
-
-/// Passes literals, but only to update their internal ranges.
-///
-/// # Arguments
-/// - `state`:
-/// - `literal`: The Literal to pass.
-fn pass_literal(state: &CompileState, literal: &mut Literal) {
-    use Literal::*;
-    match literal {
-        Null { ref mut range, .. } => {
-            offset_range!(range, state.offset);
-        },
-        Boolean { ref mut range, .. } => {
-            offset_range!(range, state.offset);
-        },
-        Integer { ref mut range, .. } => {
-            offset_range!(range, state.offset);
-        },
-        Real { ref mut range, .. } => {
-            offset_range!(range, state.offset);
-        },
-        String { ref mut range, .. } => {
-            offset_range!(range, state.offset);
-        },
-        Semver { ref mut range, .. } => {
-            offset_range!(range, state.offset);
-        },
-
-        Void { ref mut range, .. } => {
-            offset_range!(range, state.offset);
-        },
-    }
 }
 
 

--- a/brane-ast/src/warnings.rs
+++ b/brane-ast/src/warnings.rs
@@ -1,44 +1,55 @@
 //  WARNINGS.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    05 Sep 2022, 16:08:42
 //  Last edited:
-//    10 Aug 2023, 14:03:24
+//    08 Dec 2023, 15:30:10
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Defines warnings for the different compiler stages.
-// 
+//
 
 use std::fmt::{Debug, Display, Formatter, Result as FResult};
 use std::io::Write;
 
+use brane_dsl::spec::MergeStrategy;
+use brane_dsl::TextRange;
 use console::{style, Style};
 
-use brane_dsl::TextRange;
-use brane_dsl::spec::MergeStrategy;
-
-use crate::errors::{n, ewrite_range};
+use crate::errors::{ewrite_range, n};
 use crate::spec::BuiltinClasses;
 
 
 /***** HELPER FUNCTIONS *****/
 /// Prettyprints a warning with only one 'reason' to the given [`Write`]r.
-/// 
+///
 /// # Arguments
 /// - `writer`: The [`Write`]-enabled object to write the serialized warning to.
 /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
 /// - `source`: The source text to extract the line from.
 /// - `warn`: The Warning to print.
 /// - `range`: The range of the warning.
-/// 
+///
 /// # Errors
 /// This function may error if we failed to write to the given writer.
-pub(crate) fn prettywrite_warn(mut writer: impl Write, file: impl AsRef<str>, source: impl AsRef<str>, warn: &dyn Display, range: &TextRange) -> Result<(), std::io::Error> {
+pub(crate) fn prettywrite_warn(
+    mut writer: impl Write,
+    file: impl AsRef<str>,
+    source: impl AsRef<str>,
+    warn: &dyn Display,
+    range: &TextRange,
+) -> Result<(), std::io::Error> {
     // Print the top line
-    writeln!(&mut writer, "{}: {}: {}", style(format!("{}:{}:{}", file.as_ref(), n!(range.start.line), n!(range.start.col))).bold(), style("warning").yellow().bold(), warn)?;
+    writeln!(
+        &mut writer,
+        "{}: {}: {}",
+        style(format!("{}:{}:{}", file.as_ref(), n!(range.start.line), n!(range.start.col))).bold(),
+        style("warning").yellow().bold(),
+        warn
+    )?;
 
     // Print the range
     ewrite_range(&mut writer, source, range, Style::new().yellow().bold())?;
@@ -64,6 +75,8 @@ pub trait Warning: Debug + Display {}
 // Defines toplevel warnings that occur in this crate.
 #[derive(Debug)]
 pub enum AstWarning {
+    /// An warning has occurred while processing attributes.
+    AttributesWarning(AttributesWarning),
     /// An warning has occurred while analysing types.
     TypeWarning(TypeWarning),
     /// An warning has occurred while doing the actual compiling.
@@ -72,7 +85,7 @@ pub enum AstWarning {
 
 impl AstWarning {
     /// Prints the warning in a pretty way to stderr.
-    /// 
+    ///
     /// # Arguments
     /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
     /// - `source`: The source text to read the debug range from.
@@ -80,36 +93,38 @@ impl AstWarning {
     pub fn prettyprint(&self, file: impl AsRef<str>, source: impl AsRef<str>) { self.prettywrite(std::io::stderr(), file, source).unwrap() }
 
     /// Prints the warning in a pretty way to the given [`Write`]r.
-    /// 
+    ///
     /// # Arguments:
     /// - `writer`: The [`Write`]-enabled object to write to.
     /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
     /// - `source`: The source text to read the debug range from.
-    /// 
+    ///
     /// # Errors
     /// This function may error if we failed to write to the given writer.
     #[inline]
     pub fn prettywrite(&self, writer: impl Write, file: impl AsRef<str>, source: impl AsRef<str>) -> Result<(), std::io::Error> {
         use AstWarning::*;
         match self {
-            TypeWarning(warn)    => warn.prettywrite(writer, file, source),
+            AttributesWarning(warn) => warn.prettywrite(writer, file, source),
+            TypeWarning(warn) => warn.prettywrite(writer, file, source),
             CompileWarning(warn) => warn.prettywrite(writer, file, source),
         }
     }
 }
 
+impl From<AttributesWarning> for AstWarning {
+    #[inline]
+    fn from(warn: AttributesWarning) -> Self { Self::AttributesWarning(warn) }
+}
+
 impl From<TypeWarning> for AstWarning {
     #[inline]
-    fn from(warn: TypeWarning) -> Self {
-        Self::TypeWarning(warn)
-    }
+    fn from(warn: TypeWarning) -> Self { Self::TypeWarning(warn) }
 }
 
 impl From<CompileWarning> for AstWarning {
     #[inline]
-    fn from(warn: CompileWarning) -> Self {
-        Self::CompileWarning(warn)
-    }
+    fn from(warn: CompileWarning) -> Self { Self::CompileWarning(warn) }
 }
 
 impl Display for AstWarning {
@@ -117,7 +132,8 @@ impl Display for AstWarning {
     fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
         use AstWarning::*;
         match self {
-            TypeWarning(warn)    => write!(f, "{warn}"),
+            AttributesWarning(warn) => write!(f, "{warn}"),
+            TypeWarning(warn) => write!(f, "{warn}"),
             CompileWarning(warn) => write!(f, "{warn}"),
         }
     }
@@ -127,44 +143,91 @@ impl Warning for AstWarning {}
 
 
 
-/// Defines warnings that may occur during compilation.
+/// Defines warnings that may occur during attribute processing.
 #[derive(Debug)]
-pub enum TypeWarning {
-    /// A merge strategy was specified but the result not stored.
-    UnusedMergeStrategy{ merge: MergeStrategy, range: TextRange },
-
-    /// The user is returning an IntermediateResult.
-    ReturningIntermediateResult{ range: TextRange },
+pub enum AttributesWarning {
+    /// An attribute was not matched with a statement.
+    UnmatchedAttribute { range: TextRange },
 }
-
-impl TypeWarning {
+impl AttributesWarning {
     /// Prints the warning in a pretty way to stderr.
-    /// 
+    ///
     /// # Arguments
     /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
     /// - `source`: The source text to read the debug range from.
-    /// 
+    ///
     /// # Returns
     /// Nothing, but does print the warning to stderr.
     #[inline]
     pub fn prettyprint(&self, file: impl AsRef<str>, source: impl AsRef<str>) { self.prettywrite(std::io::stderr(), file, source).unwrap() }
 
     /// Prints the warning in a pretty way to the given [`Write`]r.
-    /// 
+    ///
     /// # Arguments:
     /// - `writer`: The [`Write`]-enabled object to write to.
     /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
     /// - `source`: The source text to read the debug range from.
-    /// 
+    ///
+    /// # Errors
+    /// This function may error if we failed to write to the given writer.
+    #[inline]
+    pub fn prettywrite(&self, writer: impl Write, file: impl AsRef<str>, source: impl AsRef<str>) -> Result<(), std::io::Error> {
+        use AttributesWarning::*;
+        match self {
+            UnmatchedAttribute { range } => prettywrite_warn(writer, file, source, self, range),
+        }
+    }
+}
+impl Display for AttributesWarning {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
+        use AttributesWarning::*;
+        match self {
+            UnmatchedAttribute { .. } => write!(f, "Attribute does not annotate anything"),
+        }
+    }
+}
+impl Warning for AttributesWarning {}
+
+
+
+/// Defines warnings that may occur during compilation.
+#[derive(Debug)]
+pub enum TypeWarning {
+    /// A merge strategy was specified but the result not stored.
+    UnusedMergeStrategy { merge: MergeStrategy, range: TextRange },
+
+    /// The user is returning an IntermediateResult.
+    ReturningIntermediateResult { range: TextRange },
+}
+
+impl TypeWarning {
+    /// Prints the warning in a pretty way to stderr.
+    ///
+    /// # Arguments
+    /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
+    /// - `source`: The source text to read the debug range from.
+    ///
+    /// # Returns
+    /// Nothing, but does print the warning to stderr.
+    #[inline]
+    pub fn prettyprint(&self, file: impl AsRef<str>, source: impl AsRef<str>) { self.prettywrite(std::io::stderr(), file, source).unwrap() }
+
+    /// Prints the warning in a pretty way to the given [`Write`]r.
+    ///
+    /// # Arguments:
+    /// - `writer`: The [`Write`]-enabled object to write to.
+    /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
+    /// - `source`: The source text to read the debug range from.
+    ///
     /// # Errors
     /// This function may error if we failed to write to the given writer.
     #[inline]
     pub fn prettywrite(&self, writer: impl Write, file: impl AsRef<str>, source: impl AsRef<str>) -> Result<(), std::io::Error> {
         use TypeWarning::*;
         match self {
-            UnusedMergeStrategy{ range, .. } => prettywrite_warn(writer, file, source, self, range),
+            UnusedMergeStrategy { range, .. } => prettywrite_warn(writer, file, source, self, range),
 
-            ReturningIntermediateResult{ range, .. } => prettywrite_warn(writer, file, source, self, range),
+            ReturningIntermediateResult { range, .. } => prettywrite_warn(writer, file, source, self, range),
         }
     }
 }
@@ -174,9 +237,15 @@ impl Display for TypeWarning {
     fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
         use TypeWarning::*;
         match self {
-            UnusedMergeStrategy{ merge, .. } => write!(f, "Merge strategy '{merge:?}' specified but not used; did you forget 'let <var> := parallel ...'?"),
+            UnusedMergeStrategy { merge, .. } => {
+                write!(f, "Merge strategy '{merge:?}' specified but not used; did you forget 'let <var> := parallel ...'?")
+            },
 
-            ReturningIntermediateResult{ .. } => write!(f, "Returning an {} will not let you see the result; consider committing using the builtin `commit_result()` function", BuiltinClasses::IntermediateResult.name()),
+            ReturningIntermediateResult { .. } => write!(
+                f,
+                "Returning an {} will not let you see the result; consider committing using the builtin `commit_result()` function",
+                BuiltinClasses::IntermediateResult.name()
+            ),
         }
     }
 }
@@ -189,35 +258,35 @@ impl Warning for TypeWarning {}
 #[derive(Debug)]
 pub enum CompileWarning {
     /// An On-struct was used, which is now deprecated.
-    OnDeprecated{ range: TextRange },
+    OnDeprecated { range: TextRange },
 }
 
 impl CompileWarning {
     /// Prints the warning in a pretty way to stderr.
-    /// 
+    ///
     /// # Arguments
     /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
     /// - `source`: The source text to read the debug range from.
-    /// 
+    ///
     /// # Returns
     /// Nothing, but does print the warning to stderr.
     #[inline]
     pub fn prettyprint(&self, file: impl AsRef<str>, source: impl AsRef<str>) { self.prettywrite(std::io::stderr(), file, source).unwrap() }
 
     /// Prints the warning in a pretty way to the given [`Write`]r.
-    /// 
+    ///
     /// # Arguments:
     /// - `writer`: The [`Write`]-enabled object to write to.
     /// - `file`: The 'path' of the file (or some other identifier) where the source text originates from.
     /// - `source`: The source text to read the debug range from.
-    /// 
+    ///
     /// # Errors
     /// This function may error if we failed to write to the given writer.
     #[inline]
     pub fn prettywrite(&self, writer: impl Write, file: impl AsRef<str>, source: impl AsRef<str>) -> Result<(), std::io::Error> {
         use CompileWarning::*;
         match self {
-            OnDeprecated{ range, .. } => prettywrite_warn(writer, file, source, self, range),
+            OnDeprecated { range, .. } => prettywrite_warn(writer, file, source, self, range),
         }
     }
 }
@@ -227,7 +296,9 @@ impl Display for CompileWarning {
     fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
         use CompileWarning::*;
         match self {
-            OnDeprecated{ .. } => write!(f, "'On'-structures are deprecated; they will be removed in a future release. Use location annotations instead."),
+            OnDeprecated { .. } => {
+                write!(f, "'On'-structures are deprecated; they will be removed in a future release. Use location annotations instead.")
+            },
         }
     }
 }

--- a/brane-ast/src/warnings.rs
+++ b/brane-ast/src/warnings.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    05 Sep 2022, 16:08:42
 //  Last edited:
-//    08 Dec 2023, 16:55:05
+//    12 Dec 2023, 14:56:22
 //  Auto updated?
 //    Yes
 //
@@ -311,6 +311,8 @@ pub enum MetadataWarning {
     DuplicateTag { prev: TextRange, range: TextRange },
     /// A tag was not a string.
     NonStringTag { range: TextRange },
+    /// A metadata was found without separating dot (`.`)
+    TagWithoutDot { raw: String, range: TextRange },
     /// A piece of metadata was applied (directly) to a statement that did not take it.
     UselessTag { range: TextRange },
 }
@@ -341,6 +343,7 @@ impl MetadataWarning {
         match self {
             DuplicateTag { prev, range } => prettywrite_warn_exist_new(writer, file, source, self, prev, range),
             NonStringTag { range } => prettywrite_warn(writer, file, source, self, range),
+            TagWithoutDot { range, .. } => prettywrite_warn(writer, file, source, self, range),
             UselessTag { range } => prettywrite_warn(writer, file, source, self, range),
         }
     }
@@ -351,6 +354,7 @@ impl Display for MetadataWarning {
         match self {
             DuplicateTag { .. } => write!(f, "Duplicate application of the same tag"),
             NonStringTag { .. } => write!(f, "Tags must be string literals"),
+            TagWithoutDot { raw, .. } => write!(f, "Missing dot in metadata '{raw}' to separate owner and tag"),
             UselessTag { .. } => write!(f, "Applying tag here has no effect (only has effect on entire workflow or external function calls)"),
         }
     }

--- a/brane-dsl/src/parser/ast.rs
+++ b/brane-dsl/src/parser/ast.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    10 Aug 2022, 14:00:59
 //  Last edited:
-//    08 Dec 2023, 17:30:10
+//    12 Dec 2023, 16:39:52
 //  Auto updated?
 //    Yes
 //
@@ -16,7 +16,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fmt::{Debug, Display, Formatter, Result as FResult};
 use std::rc::Rc;
-use std::str::FromStr;
+use std::str::FromStr as _;
 
 use enum_debug::EnumDebug;
 use specifications::version::{ParseError, Version};
@@ -61,7 +61,7 @@ pub struct Program {
     /// The toplevel program is simply a code block with global variables.
     pub block:    Block,
     /// Metadata for the entire program.
-    pub metadata: HashSet<String>,
+    pub metadata: HashSet<Metadata>,
 }
 
 impl Node for Program {
@@ -71,6 +71,17 @@ impl Node for Program {
 }
 
 
+
+/// Defines a pair of metadata.
+///
+/// In particular, it's a "namespaced tag".
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Metadata {
+    /// The owning user.
+    pub owner: String,
+    /// The tag itself.
+    pub tag:   String,
+}
 
 /// Defines an attribute (i.e., compiler directive).
 #[derive(Clone, Debug, EnumDebug)]
@@ -600,7 +611,7 @@ pub enum Expr {
         /// The intermediate result that this Call creates, if any. Used to only ever be the case if this call is an external call, but no more, since we're also interested in tracking this for things like `commit_result`.
         result:    HashSet<Data>,
         /// Metadata for this call. Only used for external calls.
-        metadata:  HashSet<String>,
+        metadata:  HashSet<Metadata>,
 
         /// The range of the call-expression in the source text.
         range: TextRange,

--- a/brane-dsl/src/parser/ast.rs
+++ b/brane-dsl/src/parser/ast.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    10 Aug 2022, 14:00:59
 //  Last edited:
-//    08 Dec 2023, 15:45:49
+//    08 Dec 2023, 17:30:10
 //  Auto updated?
 //    Yes
 //
@@ -59,7 +59,9 @@ pub trait Node: Clone + Debug {
 #[derive(Clone, Debug)]
 pub struct Program {
     /// The toplevel program is simply a code block with global variables.
-    pub block: Block,
+    pub block:    Block,
+    /// Metadata for the entire program.
+    pub metadata: HashSet<String>,
 }
 
 impl Node for Program {
@@ -597,6 +599,8 @@ pub enum Expr {
         input:     HashSet<Data>,
         /// The intermediate result that this Call creates, if any. Used to only ever be the case if this call is an external call, but no more, since we're also interested in tracking this for things like `commit_result`.
         result:    HashSet<Data>,
+        /// Metadata for this call. Only used for external calls.
+        metadata:  HashSet<String>,
 
         /// The range of the call-expression in the source text.
         range: TextRange,
@@ -737,7 +741,7 @@ impl Expr {
     /// A new `Expr::Call` instance.
     #[inline]
     pub fn new_call(expr: Box<Expr>, args: Vec<Box<Expr>>, range: TextRange, locations: AllowedLocations) -> Self {
-        Self::Call { expr, args, st_entry: None, locations, input: HashSet::new(), result: HashSet::new(), range }
+        Self::Call { expr, args, st_entry: None, locations, input: HashSet::new(), result: HashSet::new(), metadata: HashSet::new(), range }
     }
 
     /// Creates a new Array expression with some auxillary fields set to empty.

--- a/brane-dsl/src/parser/bakery.rs
+++ b/brane-dsl/src/parser/bakery.rs
@@ -8,27 +8,26 @@
 //     Needed,
 // };
 // use nom::{IResult, Parser};
+use std::collections::HashSet;
+
+use nom::error::VerboseError;
+use nom::IResult;
+use specifications::package::PackageIndex;
+
+use super::ast::{Block, Expr, Literal, Program, Stmt};
 use crate::scanner::Tokens;
 use crate::spec::TextRange;
-use nom::IResult;
-use nom::error::VerboseError;
-use specifications::package::PackageIndex;
-use super::ast::{Block, Expr, Literal, Program, Stmt};
 // use std::num::NonZeroUsize;
 
 ///
-///
-///
-pub fn parse_ast(
-    _input: Tokens,
-    _package_index: PackageIndex,
-) -> IResult<Tokens, Program, VerboseError<Tokens>> {
+pub fn parse_ast(_input: Tokens, _package_index: PackageIndex) -> IResult<Tokens, Program, VerboseError<Tokens>> {
     // For now, let's be really naive
     Ok((Tokens::new(&[]), Program {
-        block : Block::new(
-            vec![ Stmt::new_expr(Expr::Literal{ literal: Literal::String{ value: "<TODO>".into(), range : TextRange::none() } }, TextRange::none()) ],
+        block:    Block::new(
+            vec![Stmt::new_expr(Expr::Literal { literal: Literal::String { value: "<TODO>".into(), range: TextRange::none() } }, TextRange::none())],
             TextRange::none(),
         ),
+        metadata: HashSet::new(),
     }))
     // comb::all_consuming(multi::many0(parse_stmt))
     //     .parse(input)

--- a/brane-dsl/src/parser/bscript.rs
+++ b/brane-dsl/src/parser/bscript.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    17 Aug 2022, 16:01:41
 //  Last edited:
-//    08 Dec 2023, 15:46:41
+//    08 Dec 2023, 17:30:47
 //  Auto updated?
 //    Yes
 //
@@ -13,6 +13,7 @@
 //!   BraneScript-specific parsing functions.
 //
 
+use std::collections::HashSet;
 use std::num::NonZeroUsize;
 
 use log::trace;
@@ -151,7 +152,7 @@ pub fn parse_ast(input: Tokens) -> IResult<Tokens, Program, VerboseError<Tokens>
     // Wrap it in a program and done
     let start_pos: TextPos = stmts.first().map(|s| s.start().clone()).unwrap_or(TextPos::none());
     let end_pos: TextPos = stmts.iter().last().map(|s| s.end().clone()).unwrap_or(TextPos::none());
-    Ok((r, Program { block: Block::new(stmts, TextRange::new(start_pos, end_pos)) }))
+    Ok((r, Program { block: Block::new(stmts, TextRange::new(start_pos, end_pos)), metadata: HashSet::new() }))
 }
 
 

--- a/brane-dsl/src/scanner/scanning.rs
+++ b/brane-dsl/src/scanner/scanning.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    25 Aug 2022, 11:01:54
 //  Last edited:
-//    08 Dec 2023, 09:19:20
+//    08 Dec 2023, 15:50:49
 //  Auto updated?
 //    Yes
 //
@@ -83,7 +83,6 @@ fn keyword<'a, E: ParseError<Span<'a>> + ContextError<Span<'a>>>(input: Span<'a>
         comb::map(seq::terminated(bc::tag("import"), comb::peek(separator)), Token::Import),
         comb::map(seq::terminated(bc::tag("let"), comb::peek(separator)), Token::Let),
         comb::map(seq::terminated(bc::tag("new"), comb::peek(separator)), Token::New),
-        comb::map(seq::terminated(bc::tag("on"), comb::peek(separator)), Token::On),
         comb::map(seq::terminated(bc::tag("parallel"), comb::peek(separator)), Token::Parallel),
         comb::map(seq::terminated(bc::tag("return"), comb::peek(separator)), Token::Return),
         comb::map(seq::terminated(bc::tag("unit"), comb::peek(separator)), Token::Unit),

--- a/brane-dsl/src/scanner/tokens.rs
+++ b/brane-dsl/src/scanner/tokens.rs
@@ -1,7 +1,8 @@
-use nom::{InputIter, InputLength, InputTake, Needed, Slice};
 use std::iter::Enumerate;
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 use std::str::FromStr;
+
+use nom::{InputIter, InputLength, InputTake, Needed, Slice};
 
 type Span<'a> = nom_locate::LocatedSpan<&'a str>;
 
@@ -51,6 +52,9 @@ pub enum Token<'a> {
 
     /// `parallel`
     Parallel(Span<'a>),
+
+    /// `#`
+    Pound(Span<'a>),
 
     /// `return`
     Return(Span<'a>),
@@ -156,13 +160,7 @@ pub enum Token<'a> {
 }
 
 impl<'a> Token<'a> {
-    pub fn as_bool(&self) -> bool {
-        if let Token::Boolean(span) = self {
-            bool::from_str(span.as_ref()).unwrap()
-        } else {
-            unreachable!()
-        }
-    }
+    pub fn as_bool(&self) -> bool { if let Token::Boolean(span) = self { bool::from_str(span.as_ref()).unwrap() } else { unreachable!() } }
 
     pub fn as_i64(&self) -> i64 {
         if let Token::Integer(span) = self {
@@ -175,13 +173,7 @@ impl<'a> Token<'a> {
         }
     }
 
-    pub fn as_f64(&self) -> f64 {
-        if let Token::Real(span) = self {
-            f64::from_str(span.as_ref()).unwrap()
-        } else {
-            unreachable!()
-        }
-    }
+    pub fn as_f64(&self) -> f64 { if let Token::Real(span) = self { f64::from_str(span.as_ref()).unwrap() } else { unreachable!() } }
 
     pub fn as_string(&self) -> String {
         match &self {
@@ -190,22 +182,18 @@ impl<'a> Token<'a> {
         }
     }
 
-    pub fn is_none(&self) -> bool {
-        matches!(self, Token::None)
-    }
+    pub fn is_none(&self) -> bool { matches!(self, Token::None) }
 
     pub fn inner(&self) -> &Span {
         use Token::*;
 
         match self {
-            At(span) | And(span) | Break(span) | Class(span) | Continue(span) | Else(span) | For(span) | Function(span)
-            | If(span) | Import(span) | Let(span) | On(span) | Or(span) | Return(span) | Unit(span) | While(span)
-            | Dot(span) | Colon(span) | Comma(span) | LeftBrace(span) | LeftBracket(span) | LeftParen(span)
-            | Parallel(span) | RightBrace(span) | RightBracket(span) | RightParen(span) | Semicolon(span)
-            | Assign(span) | Equal(span) | Greater(span) | GreaterOrEqual(span) | Less(span) | LessOrEqual(span)
-            | Minus(span) | Not(span) | NotEqual(span) | Plus(span) | Slash(span) | Star(span) | Percentage(span)
-            | Null(span) | Boolean(span) | Integer(span) | Real(span) | SemVer(span) | String(span) | Ident(span)
-            | New(span) => span,
+            At(span) | And(span) | Break(span) | Class(span) | Continue(span) | Else(span) | For(span) | Function(span) | If(span) | Import(span)
+            | Let(span) | On(span) | Or(span) | Return(span) | Unit(span) | While(span) | Dot(span) | Colon(span) | Comma(span) | LeftBrace(span)
+            | LeftBracket(span) | LeftParen(span) | Parallel(span) | Pound(span) | RightBrace(span) | RightBracket(span) | RightParen(span)
+            | Semicolon(span) | Assign(span) | Equal(span) | Greater(span) | GreaterOrEqual(span) | Less(span) | LessOrEqual(span) | Minus(span)
+            | Not(span) | NotEqual(span) | Plus(span) | Slash(span) | Star(span) | Percentage(span) | Null(span) | Boolean(span) | Integer(span)
+            | Real(span) | SemVer(span) | String(span) | Ident(span) | New(span) => span,
             // None should have been filtered out already.
             None => unreachable!(),
         }
@@ -214,114 +202,58 @@ impl<'a> Token<'a> {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Tokens<'a> {
-    pub tok: &'a [Token<'a>],
+    pub tok:   &'a [Token<'a>],
     pub start: usize,
-    pub end: usize,
+    pub end:   usize,
 }
 
 impl<'a> Tokens<'a> {
-    pub fn new(vec: &'a [Token]) -> Self {
-        Tokens {
-            tok: vec,
-            start: 0,
-            end: vec.len(),
-        }
-    }
+    pub fn new(vec: &'a [Token]) -> Self { Tokens { tok: vec, start: 0, end: vec.len() } }
 }
 
 impl<'a> InputLength for Tokens<'a> {
     #[inline]
-    fn input_len(&self) -> usize {
-        self.tok.len()
-    }
+    fn input_len(&self) -> usize { self.tok.len() }
 }
 
 impl<'a> InputTake for Tokens<'a> {
     #[inline]
-    fn take(
-        &self,
-        count: usize,
-    ) -> Self {
-        Tokens {
-            tok: &self.tok[0..count],
-            start: 0,
-            end: count,
-        }
-    }
+    fn take(&self, count: usize) -> Self { Tokens { tok: &self.tok[0..count], start: 0, end: count } }
 
     #[inline]
-    fn take_split(
-        &self,
-        count: usize,
-    ) -> (Self, Self) {
+    fn take_split(&self, count: usize) -> (Self, Self) {
         let (prefix, suffix) = self.tok.split_at(count);
-        let first = Tokens {
-            tok: prefix,
-            start: 0,
-            end: prefix.len(),
-        };
-        let second = Tokens {
-            tok: suffix,
-            start: 0,
-            end: suffix.len(),
-        };
+        let first = Tokens { tok: prefix, start: 0, end: prefix.len() };
+        let second = Tokens { tok: suffix, start: 0, end: suffix.len() };
         (second, first)
     }
 }
 
 impl<'a> InputLength for Token<'a> {
     #[inline]
-    fn input_len(&self) -> usize {
-        1
-    }
+    fn input_len(&self) -> usize { 1 }
 }
 
 impl<'a> Slice<Range<usize>> for Tokens<'a> {
     #[inline]
-    fn slice(
-        &self,
-        range: Range<usize>,
-    ) -> Self {
-        Tokens {
-            tok: self.tok.slice(range.clone()),
-            start: self.start + range.start,
-            end: self.start + range.end,
-        }
+    fn slice(&self, range: Range<usize>) -> Self {
+        Tokens { tok: self.tok.slice(range.clone()), start: self.start + range.start, end: self.start + range.end }
     }
 }
 
 impl<'a> Slice<RangeTo<usize>> for Tokens<'a> {
     #[inline]
-    fn slice(
-        &self,
-        range: RangeTo<usize>,
-    ) -> Self {
-        self.slice(0..range.end)
-    }
+    fn slice(&self, range: RangeTo<usize>) -> Self { self.slice(0..range.end) }
 }
 
 impl<'a> Slice<RangeFrom<usize>> for Tokens<'a> {
     #[inline]
-    fn slice(
-        &self,
-        range: RangeFrom<usize>,
-    ) -> Self {
-        self.slice(range.start..self.end - self.start)
-    }
+    fn slice(&self, range: RangeFrom<usize>) -> Self { self.slice(range.start..self.end - self.start) }
 }
 
 impl<'a> Slice<RangeFull> for Tokens<'a> {
     #[inline]
-    fn slice(
-        &self,
-        _: RangeFull,
-    ) -> Self {
-        Tokens {
-            tok: self.tok,
-            start: self.start,
-            end: self.end,
-        }
-    }
+    fn slice(&self, _: RangeFull) -> Self { Tokens { tok: self.tok, start: self.start, end: self.end } }
 }
 
 impl<'a> InputIter for Tokens<'a> {
@@ -330,20 +262,13 @@ impl<'a> InputIter for Tokens<'a> {
     type IterElem = ::std::slice::Iter<'a, Token<'a>>;
 
     #[inline]
-    fn iter_indices(&self) -> Enumerate<::std::slice::Iter<'a, Token<'a>>> {
-        self.tok.iter().enumerate()
-    }
+    fn iter_indices(&self) -> Enumerate<::std::slice::Iter<'a, Token<'a>>> { self.tok.iter().enumerate() }
 
     #[inline]
-    fn iter_elements(&self) -> ::std::slice::Iter<'a, Token<'a>> {
-        self.tok.iter()
-    }
+    fn iter_elements(&self) -> ::std::slice::Iter<'a, Token<'a>> { self.tok.iter() }
 
     #[inline]
-    fn position<P>(
-        &self,
-        predicate: P,
-    ) -> Option<usize>
+    fn position<P>(&self, predicate: P) -> Option<usize>
     where
         P: Fn(Self::Item) -> bool,
     {
@@ -351,14 +276,7 @@ impl<'a> InputIter for Tokens<'a> {
     }
 
     #[inline]
-    fn slice_index(
-        &self,
-        count: usize,
-    ) -> Result<usize, Needed> {
-        if self.tok.len() >= count {
-            Ok(count)
-        } else {
-            Err(Needed::new(count - self.tok.len()))
-        }
+    fn slice_index(&self, count: usize) -> Result<usize, Needed> {
+        if self.tok.len() >= count { Ok(count) } else { Err(Needed::new(count - self.tok.len())) }
     }
 }

--- a/brane-dsl/src/scanner/tokens.rs
+++ b/brane-dsl/src/scanner/tokens.rs
@@ -44,9 +44,6 @@ pub enum Token<'a> {
     /// `new`
     New(Span<'a>),
 
-    /// `on`
-    On(Span<'a>),
-
     /// `|`
     Or(Span<'a>),
 
@@ -189,7 +186,7 @@ impl<'a> Token<'a> {
 
         match self {
             At(span) | And(span) | Break(span) | Class(span) | Continue(span) | Else(span) | For(span) | Function(span) | If(span) | Import(span)
-            | Let(span) | On(span) | Or(span) | Return(span) | Unit(span) | While(span) | Dot(span) | Colon(span) | Comma(span) | LeftBrace(span)
+            | Let(span) | Or(span) | Return(span) | Unit(span) | While(span) | Dot(span) | Colon(span) | Comma(span) | LeftBrace(span)
             | LeftBracket(span) | LeftParen(span) | Parallel(span) | Pound(span) | RightBrace(span) | RightBracket(span) | RightParen(span)
             | Semicolon(span) | Assign(span) | Equal(span) | Greater(span) | GreaterOrEqual(span) | Less(span) | LessOrEqual(span) | Minus(span)
             | Not(span) | NotEqual(span) | Plus(span) | Slash(span) | Star(span) | Percentage(span) | Null(span) | Boolean(span) | Integer(span)

--- a/brane-exe/src/vm.rs
+++ b/brane-exe/src/vm.rs
@@ -1,41 +1,41 @@
 //  VM.rs
 //    by Lut99
-// 
+//
 //  Created:
 //    12 Sep 2022, 17:41:33
 //  Last edited:
-//    03 Jul 2023, 16:12:36
+//    12 Dec 2023, 17:20:22
 //  Auto updated?
 //    Yes
-// 
+//
 //  Description:
 //!   Implements the VM trait, which is a simple trait for defining VMs
 //!   that use threads.
-// 
+//
 
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
-
 use brane_ast::{SymTable, Workflow};
 use specifications::profiling::ProfileScopeHandle;
 
 use crate::errors::VmError;
 use crate::spec::{CustomGlobalState, CustomLocalState, RunState, VmPlugin};
-use crate::value::FullValue;
 use crate::thread::Thread;
+use crate::value::FullValue;
 
 
 /***** TESTS *****/
 #[cfg(test)]
 pub mod tests {
-    use brane_ast::{compile_snippet, CompileResult, ParserOptions};
+    use brane_ast::fetcher::SnippetFetcher;
     use brane_ast::state::CompileState;
     use brane_ast::traversals::print::ast;
-    use brane_ast::fetcher::SnippetFetcher;
+    use brane_ast::{compile_snippet, CompileResult, ParserOptions};
     use brane_shr::utilities::{create_data_index, create_package_index, test_on_dsl_files_async};
     use specifications::data::DataIndex;
     use specifications::package::PackageIndex;
+
     use super::*;
     use crate::dummy::DummyVm;
 
@@ -43,31 +43,23 @@ pub mod tests {
     /// Tests the traversal by generating symbol tables for every file.
     #[tokio::test]
     async fn test_snippets() {
-        // Setup the simple logger
-        #[cfg(feature = "test_logging")]
-        if let Err(err) = simplelog::TermLogger::init(log::LevelFilter::Debug, Default::default(), simplelog::TerminalMode::Mixed, simplelog::ColorChoice::Auto) {
-            eprintln!("WARNING: Failed to setup logger: {err} (no logging for this session)");
-        }
-
         // Run the tests on all the files
         test_on_dsl_files_async("BraneScript", |path, code| {
             async move {
-                // if !path.to_string_lossy().contains("class.bs") { return; }
-
                 // Start by the name to always know which file this is
                 println!("{}", (0..80).map(|_| '-').collect::<String>());
                 println!("File '{}' gave us:", path.display());
 
                 // Load the package index
                 let pindex: PackageIndex = create_package_index();
-                let dindex: DataIndex    = create_data_index();
+                let dindex: DataIndex = create_data_index();
 
                 // Run the program but now line-by-line (to test the snippet function)
-                let mut source : String       = String::new();
-                let mut state  : CompileState = CompileState::new();
-                let mut vm     : DummyVm      = DummyVm::new();
+                let mut source: String = String::new();
+                let mut state: CompileState = CompileState::new();
+                let mut vm: DummyVm = DummyVm::new();
                 let mut iter = code.split('\n');
-                for (offset, l) in SnippetFetcher::new(|| { Ok(iter.next().map(|l| l.into())) }) {
+                for (offset, l) in SnippetFetcher::new(|| Ok(iter.next().map(|l| l.into()))) {
                     // Append the source (for errors only)
                     source.push_str(&l);
 
@@ -92,8 +84,10 @@ pub mod tests {
                             }
                             panic!("Failed to compile to workflow (see output above)");
                         },
-        
-                        _ => { unreachable!(); },
+
+                        _ => {
+                            unreachable!();
+                        },
                     };
 
                     // Print the file itself
@@ -120,7 +114,8 @@ pub mod tests {
                 }
                 println!("{}\n\n", (0..80).map(|_| '-').collect::<String>());
             }
-        }).await;
+        })
+        .await;
     }
 }
 
@@ -133,34 +128,34 @@ pub mod tests {
 #[async_trait]
 pub trait Vm {
     /// The type of the thread-global extension to the runtime state.
-    type GlobalState : CustomGlobalState;
+    type GlobalState: CustomGlobalState;
     /// The type of the thread-local extension to the runtime state.
-    type LocalState  : CustomLocalState;
+    type LocalState: CustomLocalState;
 
 
 
     // Child-specific
     /// A function that stores the given runtime state information in the parent struct.
-    /// 
+    ///
     /// This is important and will be used later.
-    /// 
+    ///
     /// # Arguments
     /// - `state`: The current state of the workflow we have executed.
-    /// 
+    ///
     /// # Returns
     /// Nothing, but should change the internals to return this state later upon request.
-    /// 
+    ///
     /// # Errors
     /// This function may error for its own reasons.
     fn store_state(this: &Arc<RwLock<Self>>, state: RunState<Self::GlobalState>) -> Result<(), VmError>;
 
     /// A function that returns the VM's runtime state in the parent struct.
-    /// 
+    ///
     /// This is important and will be used later.
-    /// 
+    ///
     /// # Returns
     /// The RunState of this application if it exists, or else None.
-    /// 
+    ///
     /// # Errors
     /// This function may error for its own reasons.
     fn load_state(this: &Arc<RwLock<Self>>) -> Result<RunState<Self::GlobalState>, VmError>;
@@ -169,31 +164,33 @@ pub trait Vm {
 
     // Global
     /// Initializes a new global state based on the given custom part.
-    /// 
+    ///
     /// # Arguments
     /// - `pindex`: The package index which we can use for resolving packages.
     /// - `dindex`: The data index which we can use for resolving datasets.
     /// - `custom`: The custom part of the global state with which we will initialize it.
-    /// 
+    ///
     /// # Returns
     /// A new RunState instance.
     #[inline]
-    fn new_state(custom: Self::GlobalState) -> RunState<Self::GlobalState> {
-        RunState::new(Arc::new(SymTable::new()), Arc::new(RwLock::new(custom)))
-    }
+    fn new_state(custom: Self::GlobalState) -> RunState<Self::GlobalState> { RunState::new(Arc::new(SymTable::new()), Arc::new(RwLock::new(custom))) }
 
     /// Runs the given workflow, possibly asynchronously (if a parallel is encountered / there are external functions calls and the given closure runs this asynchronously.)
-    /// 
+    ///
     /// # Generic arguments
     /// - `P`: The "VM plugin" that will fill in the blanks with respect to interacting with the outside world.
-    /// 
+    ///
     /// # Arguments
     /// - `snippet`: The snippet to compile. This is either the entire workflow, or a snippet of it. In the case of the latter, the internal state will be used (and updated).
     /// - `prof`: The ProfileScope that can be used to provide additional information about the timings of the VM (framework-wise, not user-wise).
-    /// 
+    ///
     /// # Returns
     /// The result if the Workflow returned any.
-    async fn run<P: VmPlugin<GlobalState = Self::GlobalState, LocalState = Self::LocalState>>(this: Arc<RwLock<Self>>, snippet: Workflow, prof: ProfileScopeHandle<'_>) -> Result<FullValue, VmError>
+    async fn run<P: VmPlugin<GlobalState = Self::GlobalState, LocalState = Self::LocalState>>(
+        this: Arc<RwLock<Self>>,
+        snippet: Workflow,
+        prof: ProfileScopeHandle<'_>,
+    ) -> Result<FullValue, VmError>
     where
         Self: Sync,
     {

--- a/brane-plr/src/planner.rs
+++ b/brane-plr/src/planner.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    25 Oct 2022, 11:35:00
 //  Last edited:
-//    07 Nov 2023, 17:37:26
+//    12 Dec 2023, 16:10:38
 //  Auto updated?
 //    Yes
 //
@@ -160,7 +160,7 @@ async fn plan_edges(
         }
         done.insert(pc);
         match edge {
-            Edge::Node { task, locs, at, input, result, next } => {
+            Edge::Node { task, locs, at, input, result, metadata: _, next } => {
                 // This is the node where it all revolves around, in the end
                 debug!("Planning task '{}' (edge {})...", table.tasks[*task].name(), pc);
 

--- a/make.py
+++ b/make.py
@@ -5,7 +5,7 @@
 # Created:
 #   09 Jun 2022, 12:20:28
 # Last edited:
-#   22 Oct 2023, 17:52:48
+#   12 Dec 2023, 16:13:00
 # Auto updated?
 #   Yes
 #
@@ -3276,7 +3276,7 @@ for svc in instance_srcs:
 # A list of all targets in the make file.
 targets = {
     "test-units"  : ShellTarget("test-units",
-        [ ShellCommand("cargo", "test", "--all-targets", "--all-features") ],
+        [ ShellCommand("cargo", "test", "--all", "--all-targets", "--all-features") ],
         description="Runs tests on the project by running the unit tests.",
     ),
     "test-clippy" : ShellTarget("test-clippy",

--- a/tests/branescript/attributes.bs
+++ b/tests/branescript/attributes.bs
@@ -1,0 +1,56 @@
+// File that showcases some attribute usage
+
+import hello_world;   // hello_world()
+
+// Attributes can be used to provide additional context to the compiler
+// Typically, one is attached to a statement by prefixing it; for example, this tags this call to `hello_world()` with `foo`
+#[tag("foo")]
+println(hello_world());
+
+// One can also attach an attribute to an entire scope, applying it to all statements in it;
+// This...
+{
+    #[tag("bar")]
+    println(hello_world());
+    #[tag("bar")]
+    println(hello_world());
+}
+// ...is equivalent to...
+#[tag("bar")]
+{
+    println(hello_world());
+    println(hello_world());
+}
+
+// One can also use the `#![...]` syntax to attach an attribute to a whole scope from _within_ that scope
+// This equals the previous example:
+{
+    #![tag("bar")]
+    println(hello_world());
+    println(hello_world());
+}
+
+// We can use this latter fact to annotate an entire workflow
+// (Note that attributes are ordered, so this is only applied to statements from now onwards)
+#![tag("baz")]
+println(hello_world());
+println(hello_world());
+
+
+
+// Finally, there are some subteties to if-, for-, while- and parallel-statements
+// When applied to the whole statement, it applies to *all* its blocks and *all* its expressions; i.e., in
+#[tag("qaz")]
+if (hello_world() == "Hello, world!") {
+    println(hello_world());
+} else {
+    println(hello_world());
+}
+// all `hello_world()`-calls are executed with a `qaz`-tag. However, in this case;
+if (hello_world() == "Hello, world!") {
+    #![tag("qaz")]
+    println(hello_world());
+} else {
+    println(hello_world());
+}
+// only the call in the true-branch is.

--- a/tests/branescript/attributes.bs
+++ b/tests/branescript/attributes.bs
@@ -3,20 +3,20 @@
 import hello_world;   // hello_world()
 
 // Attributes can be used to provide additional context to the compiler
-// Typically, one is attached to a statement by prefixing it; for example, this tags this call to `hello_world()` with `foo`
-#[tag("foo")]
+// Typically, one is attached to a statement by prefixing it; for example, this tags this call to `hello_world()` with `amy.foo`
+#[tag("amy.foo")]
 println(hello_world());
 
 // One can also attach an attribute to an entire scope, applying it to all statements in it;
 // This...
 {
-    #[tag("bar")]
+    #[tag("bob.bar")]
     println(hello_world());
-    #[tag("bar")]
+    #[tag("bob.bar")]
     println(hello_world());
 }
 // ...is equivalent to...
-#[tag("bar")]
+#[tag("bob.bar")]
 {
     println(hello_world());
     println(hello_world());
@@ -25,14 +25,15 @@ println(hello_world());
 // One can also use the `#![...]` syntax to attach an attribute to a whole scope from _within_ that scope
 // This equals the previous example:
 {
-    #![tag("bar")]
+    #![tag("bob.bar")]
     println(hello_world());
     println(hello_world());
 }
 
-// We can use this latter fact to annotate an entire workflow
-// (Note that attributes are ordered, so this is only applied to statements from now onwards)
-#![tag("baz")]
+// We can use this latter fact to annotate an entire workflow...
+#![wf_tag("cho.baz")]
+// ...or all statements in the entire workflow (note this also applies to previous statements!)
+#![tag("dan.qux")]
 println(hello_world());
 println(hello_world());
 
@@ -40,7 +41,7 @@ println(hello_world());
 
 // Finally, there are some subteties to if-, for-, while- and parallel-statements
 // When applied to the whole statement, it applies to *all* its blocks and *all* its expressions; i.e., in
-#[tag("qaz")]
+#[tag("eve.quux")]
 if (hello_world() == "Hello, world!") {
     println(hello_world());
 } else {
@@ -48,7 +49,7 @@ if (hello_world() == "Hello, world!") {
 }
 // all `hello_world()`-calls are executed with a `qaz`-tag. However, in this case;
 if (hello_world() == "Hello, world!") {
-    #![tag("qaz")]
+    #![tag("eve.quux")]
     println(hello_world());
 } else {
     println(hello_world());

--- a/tests/branescript/epi.bs
+++ b/tests/branescript/epi.bs
@@ -8,7 +8,7 @@ let res_sta := local_compute(new Data{ name := "st_antonius_ect" });
 let res_umc := local_compute(new Data{ name := "umc_utrecht_ect" });
 
 // Do the aggregation step
-on "surf" {
-    let res := aggregate(res_sta, res_umc);
-    return commit_result("surf_res", res);
-}
+#[loc("surf")]
+let res := aggregate(res_sta, res_umc);
+return commit_result("surf_res", res);
+

--- a/tests/branescript/epi_one.bs
+++ b/tests/branescript/epi_one.bs
@@ -7,7 +7,7 @@ import epi;
 let res_umc := local_compute(new Data{ name := "umc_utrecht_ect" });
 
 // Do the aggregation step with that same dataset twice lol
-on "surf" {
-    let res := aggregate(res_umc, res_umc);
-    return commit_result("surf_res", res);
-}
+#[loc("surf")]
+let res := aggregate(res_umc, res_umc);
+return commit_result("surf_res", res);
+

--- a/tests/branescript/metadata.bs
+++ b/tests/branescript/metadata.bs
@@ -1,0 +1,7 @@
+import hello_world;
+
+#![wf_tag("foo", "bar", "baz")]
+
+#[tag("foo2", "bar2", "baz2")]
+#[on("test")]
+println(hello_world());

--- a/tests/branescript/on.bs
+++ b/tests/branescript/on.bs
@@ -2,11 +2,8 @@ import test;
 
 hello_world();
 
-// @["test"]
-// hello_world();
-
 // Test an on-statement
-#[loc("test")]
+#[on("test")]
 {
     println("I'm talking to you from far away!");
     hello_world();
@@ -14,7 +11,7 @@ hello_world();
 
 let random := "random";
 {
-    #![loc("random_but_not_really_anymore")]
+    #![on("random_but_not_really_anymore")]
     println("I have no idea where I am!");
     hello_world();
 }
@@ -22,7 +19,7 @@ let random := "random";
 func fourty_two() {
     return "42";
 }
-#[loc("42")]
+#[on("42")]
 {
     println("I have found the answer");
     hello_world();

--- a/tests/branescript/on.bs
+++ b/tests/branescript/on.bs
@@ -6,13 +6,15 @@ hello_world();
 // hello_world();
 
 // Test an on-statement
-on "test" {
+#[loc("test")]
+{
     println("I'm talking to you from far away!");
     hello_world();
 }
 
 let random := "random";
-on "random_but_not_really_anymore" {
+{
+    #![loc("random_but_not_really_anymore")]
     println("I have no idea where I am!");
     hello_world();
 }
@@ -20,7 +22,8 @@ on "random_but_not_really_anymore" {
 func fourty_two() {
     return "42";
 }
-on "42" {
+#[loc("42")]
+{
     println("I have found the answer");
     hello_world();
 }

--- a/tests/branescript/parallel.bs
+++ b/tests/branescript/parallel.bs
@@ -25,6 +25,7 @@ println(sum);
 
 parallel [{
     println("Running somewhere randomly!");
-}, on "specific_location" {
+}, {
+    #![on("some_location")]
     println("Running somewhere specific but in parallel!");
 }];


### PR DESCRIPTION
Attributes are now used to scope task calls (`on`, `loc` or `location`) or to supply the workflow/a task with metadata (`wf_tag`, `workflow_tag`, `wf_metadata` or `workflow_metadata`).

As part of this change, removed `on`-structs (finally!).
