### PR TITLE
User friendly error and fix image build target names.

### DIFF
--- a/make.py
+++ b/make.py
@@ -3759,6 +3759,10 @@ def build_target(target_name, args) -> int:
         This function acts as the 'main' function of the script.
     """
 
+    if target_name not in targets:
+        perror(f"Could not find target: {target_name}")
+        return 1
+
     # Do a warning
     if args.dry_run:
         pwarning("Simulating build only; no commands are actually run (due to '--dry-run')")

--- a/make.py
+++ b/make.py
@@ -3450,7 +3450,7 @@ for svc in CENTRAL_SERVICES + WORKER_SERVICES:
         )
 
     # Generate the service image build target
-    targets[f"{svc}-image"] = EitherTarget(f"{svc}-image-build",
+    targets[f"{svc}-image"] = EitherTarget(f"{svc}-image",
         "dev", {
             False : ImageTarget(f"{svc}-image-release",
                 "./Dockerfile.rls", f"./target/release/brane-{svc}.tar", target=f"brane-{svc}",


### PR DESCRIPTION
In the list of targets there targets ending in `-image-build` which do not actually exist. I renamed them to the `-image` targets so they match with the existing target. I am unfamiliar with `make.py` and it is complicated to graps at times, so it would be nice if this was checked.

Additionally, we should now print a friendly error when somebody tries to make a non-existent target instead of failing inside the dep tree.