### PR TITLE
fix(clippy): Correct various clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,6 @@ documentation = "https://wiki.enablingpersonalizedinterventions.nl"
 name = "brane-meta"
 version.workspace = true
 edition = "2021"
+
+[lints.clippy]
+result_large_err = { level = "allow", priority = 1 }

--- a/brane-api/src/health.rs
+++ b/brane-api/src/health.rs
@@ -20,9 +20,6 @@ use warp::hyper::Body;
 use warp::{Reply, Rejection};
 
 
-///
-///
-///
 pub async fn handle() -> Result<impl Reply, Rejection> {
     let mut response = Response::new(Body::from("OK!\n"));
 

--- a/brane-ast/src/traversals/data.rs
+++ b/brane-ast/src/traversals/data.rs
@@ -159,7 +159,7 @@ fn pass_stmt(stmt: &mut Stmt, table: &mut DataState, is_branch: bool, scope: &Rc
             if let Some(expr) = expr {
                 // Return whether the expression returns any datasets
                 let res: HashSet<Data> = pass_expr(expr, table);
-                *output = res.clone();
+                output.clone_from(&res);
                 res
             } else {
                 // Otherwise, it doesn't return any new identifiers
@@ -320,7 +320,7 @@ fn pass_expr(expr: &mut Expr, table: &DataState) -> HashSet<Data> {
                         let res: HashSet<Data> = HashSet::from([Data::IntermediateResult(id)]);
 
                         // Note it in the function
-                        *result = res.clone();
+                        result.clone_from(&res);
 
                         // Return the identifier to return from this call
                         res
@@ -332,11 +332,11 @@ fn pass_expr(expr: &mut Expr, table: &DataState) -> HashSet<Data> {
                     // It's an internal call. As such, propagate what we know of the symbol table declaration (or rather, compile state).
                     if entry.name == BuiltinFunctions::CommitResult.name() {
                         // Attempt to find out the name of the dataset
-                        let arg: &Expr = args.get(0).unwrap();
+                        let arg: &Expr = args.first().unwrap();
                         if let Expr::Literal { literal: brane_dsl::ast::Literal::String { value, .. } } = arg {
                             // OK return that as a data
                             let res: HashSet<Data> = HashSet::from([Data::Data(value.clone())]);
-                            *result = res.clone();
+                            result.clone_from(&res);
                             res
                         } else {
                             panic!("Got non-string-literal name argument for builtin `commit_result()`");

--- a/brane-cfg/src/infra.rs
+++ b/brane-cfg/src/infra.rs
@@ -79,6 +79,9 @@ impl InfraFile {
     /// Returns the number of locations in this file.
     #[inline]
     pub fn len(&self) -> usize { self.locations.len() }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.locations.len() == 0 }
 }
 impl<'de> YamlInfo<'de> for InfraFile {}
 

--- a/brane-cli-c/src/lib.rs
+++ b/brane-cli-c/src/lib.rs
@@ -849,6 +849,7 @@ pub unsafe extern "C" fn workflow_free(workflow: *mut Workflow) {
 /// # Panics
 /// This function can panic if the given `workflow` is a NULL-pointer, or if the given `user` is not valid UTF-8/a NULL-pointer.
 #[no_mangle]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn workflow_set_user(workflow: *mut Workflow, user: *const c_char) {
     // Set the output to NULL
     init_logger();
@@ -1060,7 +1061,7 @@ pub unsafe extern "C" fn compiler_compile(
     compiler.source.push('\n');
 
     // Compile that using `brane-ast`
-    serr.source = compiler.source.clone();
+    serr.source.clone_from(&compiler.source);
     let wf: Workflow = {
         // Acquire locks on the indices
         let pindex: MutexGuard<PackageIndex> = compiler.pindex.lock();

--- a/brane-cli/src/instance.rs
+++ b/brane-cli/src/instance.rs
@@ -306,6 +306,7 @@ impl InstanceInfo {
 ///
 /// # Errors
 /// This function errors if we failed to generate any files, or if some check failed for this instance.
+#[allow(clippy::too_many_arguments)]
 pub async fn add(
     name: String,
     hostname: Hostname,
@@ -321,7 +322,7 @@ pub async fn add(
     // Assert the name is valid
     debug!("Asserting name validity...");
     for c in name.chars() {
-        if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '.' && c != '-' {
+        if !c.is_ascii_lowercase() && !c.is_ascii_uppercase() && !c.is_ascii_digit() && c != '_' && c != '.' && c != '-' {
             return Err(Error::IllegalInstanceName { raw: name, illegal_char: c });
         }
     }

--- a/brane-cli/src/planner.rs
+++ b/brane-cli/src/planner.rs
@@ -463,7 +463,7 @@ impl Planner for OfflinePlanner {
         }
 
         // Flush the results back to the internal results table
-        *self.results.lock() = table.results.clone();
+        self.results.lock().clone_from(&table.results);
 
         // Then, put the table back
         let mut table: Arc<SymTable> = Arc::new(table);

--- a/brane-cli/src/registry.rs
+++ b/brane-cli/src/registry.rs
@@ -382,9 +382,6 @@ pub async fn push(packages: Vec<(String, Version)>) -> Result<(), RegistryError>
 }
 /*******/
 
-///
-///
-///
 pub async fn search(term: Option<String>) -> Result<()> {
     #[derive(GraphQLQuery)]
     #[graphql(
@@ -437,9 +434,6 @@ pub async fn search(term: Option<String>) -> Result<()> {
     Ok(())
 }
 
-///
-///
-///
 pub async fn unpublish(
     name: String,
     version: Version,

--- a/brane-cli/src/run.rs
+++ b/brane-cli/src/run.rs
@@ -61,6 +61,8 @@ use crate::vm::OfflineVm;
 ///
 /// # Errors
 /// This function errors if the given string was not a valid workflow. If that's the case, it's also pretty-printed to stdout with source context.
+
+#[allow(clippy::too_many_arguments)]
 fn compile(
     state: &mut CompileState,
     source: &mut String,
@@ -149,6 +151,7 @@ fn compile(
 ///
 /// # Errors
 /// This function may error if we failed to reach the remote driver, or if the given session did not exist.
+#[allow(clippy::too_many_arguments)]
 pub async fn initialize_instance<O: Write, E: Write>(
     stdout_writer: O,
     stderr_writer: E,
@@ -776,7 +779,7 @@ pub async fn run_instance_vm(
         // Acquire the locks
         let pindex: MutexGuard<PackageIndex> = state.pindex.lock();
         let dindex: MutexGuard<DataIndex> = state.dindex.lock();
-        compile(&mut state.state, &mut state.source, &pindex, &dindex, state.user.as_ref().map(|u| u.as_str()), &state.options, what, snippet)?
+        compile(&mut state.state, &mut state.source, &pindex, &dindex, state.user.as_deref(), &state.options, what, snippet)?
     };
 
     // Run the thing using the other function

--- a/brane-cli/src/spec.rs
+++ b/brane-cli/src/spec.rs
@@ -95,7 +95,7 @@ impl FromStr for Hostname {
 
             // Assert the scheme only has alphanumeric characters
             for c in scheme.chars() {
-                if (c < '0' || c > '9') && (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
+                if !c.is_ascii_digit() && !c.is_ascii_lowercase() && !c.is_ascii_uppercase() {
                     return Err(HostnameParseError::IllegalSchemeChar { raw: scheme.into(), c });
                 }
             }

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -56,3 +56,6 @@ features = ["vendored"]
 [build-dependencies]
 download = { git = "https://github.com/Lut99/download-rs", default-features = false, features = ["download"] }
 hex-literal = "0.4"
+
+[lints.clippy]
+result_large_err = { level = "allow", priority = 1 }

--- a/brane-ctl/src/generate.rs
+++ b/brane-ctl/src/generate.rs
@@ -809,7 +809,7 @@ pub fn node(
                         policy_database: canonicalize(policy_database)?,
                         policy_deliberation_secret: canonicalize(policy_deliberation_secret)?,
                         policy_expert_secret: canonicalize(policy_expert_secret)?,
-                        policy_audit_log: policy_audit_log.map(|p| canonicalize(p)).transpose()?,
+                        policy_audit_log: policy_audit_log.map(canonicalize).transpose()?,
                         proxy: if external_proxy.is_some() { None } else { Some(canonicalize(proxy)?) },
 
                         data: canonicalize(data)?,
@@ -1408,7 +1408,7 @@ pub fn policy_secret(fix_dirs: bool, path: PathBuf, key_id: String, key_alg: Key
             // Generate a 256-bit, base64-encoded random string of bytes
             // See: <https://datatracker.ietf.org/doc/html/rfc7518#section-6.4.1>
             let mut key: [u8; 32] = [0; 32];
-            OsRng::default().fill(&mut key);
+            OsRng.fill(&mut key);
             base64ct::Base64Url::encode_string(&key)
         },
 

--- a/brane-ctl/src/lifetime.rs
+++ b/brane-ctl/src/lifetime.rs
@@ -325,7 +325,7 @@ fn prepare_host(node_config: &NodeConfig) -> Result<(), Error> {
             if let Some(policy_audit_log) = policy_audit_log {
                 if !policy_audit_log.exists() {
                     debug!("Generating empty persistent audit log at '{}'...", policy_audit_log.display());
-                    if let Err(err) = File::create(&policy_audit_log) {
+                    if let Err(err) = File::create(policy_audit_log) {
                         return Err(Error::AuditLogCreate { path: policy_audit_log.clone(), err });
                     }
                 }

--- a/brane-ctl/src/policies.rs
+++ b/brane-ctl/src/policies.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    10 Jan 2024, 15:57:54
 //  Last edited:
-//    06 Mar 2024, 14:06:05
+//    24 Jun 2024, 17:40:43
 //  Auto updated?
 //    Yes
 //
@@ -848,5 +848,7 @@ pub async fn list(node_config_path: PathBuf, address: AddressOpt, token: Option<
         };
     }
 
+    // TODO: Finish this. The idea is show a particular version to the user, then re-enter the loop until they quit
+    //       (empty version, as above)
     todo!();
 }

--- a/brane-ctl/src/spec.rs
+++ b/brane-ctl/src/spec.rs
@@ -321,6 +321,7 @@ pub enum DownloadServicesSubcommand {
 
 /// A bit awkward here, but defines the generate subcommand for the node file. This basically defines the possible kinds of nodes to generate.
 #[derive(Debug, EnumDebug, Subcommand)]
+#[allow(clippy::large_enum_variant)] // We should only have one anyway
 pub enum GenerateNodeSubcommand {
     /// Starts a central node.
     #[clap(name = "central", about = "Generates a node.yml file for a central node with default values.")]
@@ -616,7 +617,7 @@ impl GenerateCertsSubcommand {
         match self {
             Server { location_id, hostname, .. } | Client { location_id, hostname, .. } => {
                 if hostname == "$LOCATION_ID" {
-                    *hostname = location_id.clone();
+                    hostname.clone_from(location_id);
                 }
             },
         }

--- a/brane-ctl/src/wizard.rs
+++ b/brane-ctl/src/wizard.rs
@@ -176,11 +176,11 @@ where
         } else if !ext && (c == ' ' || c == '-' || c == '_') {
             // Write it as a space
             header_name.push(' ');
-        } else if !ext && saw_lowercase && c >= 'A' && c <= 'Z' {
+        } else if !ext && saw_lowercase && c.is_ascii_uppercase() {
             // Write is with a space, since we assume it's a word boundary in camelCase
             header_name.push(' ');
             header_name.push(c);
-        } else if !ext && c >= 'a' && c <= 'z' {
+        } else if !ext && c.is_ascii_lowercase() {
             // Capitalize it
             header_name.push((c as u8 - b'a' + b'A') as char);
         } else {
@@ -189,7 +189,7 @@ where
         }
 
         // Update whether we saw a lowercase last step
-        saw_lowercase = c >= 'a' && c <= 'z';
+        saw_lowercase = c.is_ascii_lowercase();
     }
 
     // Create a file, now

--- a/brane-dsl/src/parser/bakery.rs
+++ b/brane-dsl/src/parser/bakery.rs
@@ -19,7 +19,6 @@ use crate::scanner::Tokens;
 use crate::spec::TextRange;
 // use std::num::NonZeroUsize;
 
-///
 pub fn parse_ast(_input: Tokens, _package_index: PackageIndex) -> IResult<Tokens, Program, VerboseError<Tokens>> {
     // For now, let's be really naive
     Ok((Tokens::new(&[]), Program {

--- a/brane-exe/src/dummy.rs
+++ b/brane-exe/src/dummy.rs
@@ -315,7 +315,7 @@ impl DummyPlanner {
         }
 
         // Write the results to the global state
-        *state_results = table.results.clone();
+        state_results.clone_from(&table.results);
 
         // Then, put the table back
         let mut table: Arc<SymTable> = Arc::new(table);

--- a/brane-exe/src/thread.rs
+++ b/brane-exe/src/thread.rs
@@ -179,7 +179,7 @@ enum EdgeResult {
 /// # Errors
 /// This function may error if the given `input` does not contain any of the data in the value _or_ if the referenced input is not yet planned.
 #[async_recursion]
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::multiple_bound_locations)]
 async fn preprocess_value<'p: 'async_recursion, P: VmPlugin>(
     global: &Arc<RwLock<P::GlobalState>>,
     local: &P::LocalState,

--- a/brane-job/src/worker.rs
+++ b/brane-job/src/worker.rs
@@ -288,6 +288,7 @@ impl TaskInfo {
     /// # Returns
     /// A new TaskInfo instance.
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: impl Into<String>,
         pc: ProgramCounter,
@@ -339,6 +340,7 @@ impl TaskInfo {
 ///
 /// # Errors
 /// This function can error for literally a million reasons - but they mostly relate to IO (file access, request success etc).
+#[allow(clippy::too_many_arguments)]
 async fn preprocess_transfer_tar_local(
     location_cache: &DomainRegistryCache,
     worker_cfg: &WorkerConfig,
@@ -542,6 +544,7 @@ async fn preprocess_transfer_tar_local(
 ///
 /// # Errors
 /// This function can error for literally a million reasons - but they mostly relate to IO (file access, request success etc).
+#[allow(clippy::too_many_arguments)]
 pub async fn preprocess_transfer_tar(
     location_cache: &DomainRegistryCache,
     worker_cfg: &WorkerConfig,
@@ -1801,7 +1804,7 @@ impl WorkerServer {
             worker.usecases.into_iter().map(|(usecase, reg)| (usecase, DomainRegistryCache::new(reg.api))).collect();
 
         // OK, return self
-        Ok(Self { node_config_path: node_config_path.into(), keep_containers, proxy, registries: Arc::new(registries) })
+        Ok(Self { node_config_path, keep_containers, proxy, registries: Arc::new(registries) })
     }
 }
 
@@ -1857,7 +1860,7 @@ impl JobService for WorkerServer {
             Some(dataname) => dataname.into(),
             None => {
                 error!("Failed to parse dataname in incoming request");
-                return Err(Status::invalid_argument(format!("Invalid request: could not parse dataname")));
+                return Err(Status::invalid_argument("Invalid request: could not parse dataname".to_string()));
             },
         };
 

--- a/brane-let/src/exec_ecu.rs
+++ b/brane-let/src/exec_ecu.rs
@@ -401,23 +401,21 @@ async fn complete(
         tokio::pin!(sleep);
 
         // Wait for either the timer or the process
-        let status = loop {
-            tokio::select! {
-                status = process.wait() => {
-                    // Process is finished!
-                    break Some(status);
-                },
-                _ = &mut sleep => {
-                    // // Timeout occurred; send the heartbeat and continue
-                    // if let Some(callback) = callback {
-                    //     if let Err(err) = callback.heartbeat().await { warn!("Could not update driver on Heartbeat: {}", err); }
-                    //     else { debug!("Sent Heartbeat to driver."); }
-                    // }
+        let status = tokio::select! {
+            status = process.wait() => {
+                // Process is finished!
+                Some(status)
+            },
+            _ = &mut sleep => {
+                // // Timeout occurred; send the heartbeat and continue
+                // if let Some(callback) = callback {
+                //     if let Err(err) = callback.heartbeat().await { warn!("Could not update driver on Heartbeat: {}", err); }
+                //     else { debug!("Sent Heartbeat to driver."); }
+                // }
 
-                    // Stop without result
-                    break None;
-                },
-            }
+                // Stop without result
+                None
+            },
         };
 
         // If we have a result, break from the main loop; otherwise, try again

--- a/brane-let/src/exec_oas.rs
+++ b/brane-let/src/exec_oas.rs
@@ -216,23 +216,21 @@ async fn complete(
         tokio::pin!(sleep);
 
         // Wait for either the timer or the process
-        let status = loop {
-            tokio::select! {
-                result = brane_oas::execute(function, arguments, oas_doc) => {
-                    // Process is finished!
-                    break Some(result);
-                },
-                _ = &mut sleep => {
-                    // // Timeout occurred; send the heartbeat and continue
-                    // if let Some(callback) = callback {
-                    //     if let Err(err) = callback.heartbeat().await { warn!("Could not update driver on Heartbeat: {}", err); }
-                    //     else { debug!("Sent Heartbeat to driver."); }
-                    // }
+        let status = tokio::select! {
+            result = brane_oas::execute(function, arguments, oas_doc) => {
+                // Process is finished!
+                Some(result)
+            },
+            _ = &mut sleep => {
+                // // Timeout occurred; send the heartbeat and continue
+                // if let Some(callback) = callback {
+                //     if let Err(err) = callback.heartbeat().await { warn!("Could not update driver on Heartbeat: {}", err); }
+                //     else { debug!("Sent Heartbeat to driver."); }
+                // }
 
-                    // Stop without result
-                    break None;
-                },
-            }
+                // Stop without result
+                None
+            },
         };
 
         // If we have a result, break from the main loop; otherwise, try again

--- a/brane-oas/src/build.rs
+++ b/brane-oas/src/build.rs
@@ -178,9 +178,6 @@ pub fn build_oas_function(
     Ok((functions, types))
 }
 
-///
-///
-///
 fn build_oas_function_input(
     operation_id: &str,
     operation: &Operation,
@@ -274,9 +271,6 @@ fn build_oas_function_input(
     Ok((input_parameters, input_types))
 }
 
-///
-///
-///
 fn build_oas_function_output(
     operation_id: &str,
     operation: &Operation,
@@ -338,9 +332,6 @@ fn build_oas_function_output(
     Ok((return_type, output_types))
 }
 
-///
-///
-///
 fn parameter_to_properties(
     parameter: &OParameter,
     components: &Option<Components>,
@@ -365,9 +356,6 @@ fn parameter_to_properties(
     }
 }
 
-///
-///
-///
 pub fn schema_to_properties(
     name: Option<String>,
     schema: &Schema,
@@ -383,9 +371,6 @@ pub fn schema_to_properties(
     }
 }
 
-///
-///
-///
 fn any_schema_to_properties(
     name: Option<String>,
     schema: &Schema,
@@ -442,9 +427,6 @@ fn any_schema_to_properties(
     Ok(properties)
 }
 
-///
-///
-///
 fn type_schema_to_properties(
     name: Option<String>,
     schema: &Schema,

--- a/brane-oas/src/execute.rs
+++ b/brane-oas/src/execute.rs
@@ -12,9 +12,6 @@ use std::{collections::HashMap, sync::Arc};
 
 type Map<T> = std::collections::HashMap<String, T>;
 
-///
-///
-///
 pub async fn execute(
     operation_id: &str,
     arguments: &Map<FullValue>,
@@ -194,9 +191,6 @@ async fn perform_request(client: RequestBuilder) -> Result<String, Error<reqwest
     retry(backoff, op)
 }
 
-///
-///
-///
 pub fn get_operation(
     operation_id: &str,
     oas_document: &OpenAPI,

--- a/brane-oas/src/lib.rs
+++ b/brane-oas/src/lib.rs
@@ -17,9 +17,6 @@ pub mod resolver;
 
 pub use execute::execute;
 
-///
-///
-///
 pub fn parse_oas_file<P: Into<PathBuf>>(oas_file: P) -> Result<OpenAPI> {
     let oas_file: PathBuf = oas_file.into();
     let extension = oas_file.extension().unwrap_or_default();

--- a/brane-oas/src/resolver.rs
+++ b/brane-oas/src/resolver.rs
@@ -5,9 +5,6 @@ use openapiv3::{
     SecurityScheme,
 };
 
-///
-///
-///
 pub fn resolve_path_item(item: &ReferenceOr<PathItem>) -> Result<PathItem> {
     match item {
         ReferenceOr::Item(item) => Ok(item.clone()),
@@ -15,9 +12,6 @@ pub fn resolve_path_item(item: &ReferenceOr<PathItem>) -> Result<PathItem> {
     }
 }
 
-///
-///
-///
 pub fn resolve_security_scheme(
     item: &ReferenceOr<SecurityScheme>,
     components: &Option<Components>,
@@ -40,9 +34,6 @@ pub fn resolve_security_scheme(
     }
 }
 
-///
-///
-///
 pub fn resolve_response(
     item: &ReferenceOr<Response>,
     components: &Option<Components>,
@@ -65,9 +56,6 @@ pub fn resolve_response(
     }
 }
 
-///
-///
-///
 pub fn resolve_parameter(
     item: &ReferenceOr<Parameter>,
     components: &Option<Components>,
@@ -90,9 +78,6 @@ pub fn resolve_parameter(
     }
 }
 
-///
-///
-///
 pub fn resolve_example(
     item: &ReferenceOr<Example>,
     components: &Option<Components>,
@@ -115,9 +100,6 @@ pub fn resolve_example(
     }
 }
 
-///
-///
-///
 pub fn resolve_request_body(
     item: &ReferenceOr<RequestBody>,
     components: &Option<Components>,
@@ -140,9 +122,6 @@ pub fn resolve_request_body(
     }
 }
 
-///
-///
-///
 pub fn resolve_headers(
     item: &ReferenceOr<Header>,
     components: &Option<Components>,
@@ -165,9 +144,6 @@ pub fn resolve_headers(
     }
 }
 
-///
-///
-///
 pub fn resolve_schema(
     item: &ReferenceOr<Schema>,
     components: &Option<Components>,
@@ -190,9 +166,6 @@ pub fn resolve_schema(
     }
 }
 
-///
-///
-///
 pub fn resolve_links(
     item: &ReferenceOr<Link>,
     components: &Option<Components>,
@@ -215,9 +188,6 @@ pub fn resolve_links(
     }
 }
 
-///
-///
-///
 pub fn resolve_callback(
     item: &ReferenceOr<Callback>,
     components: &Option<Components>,

--- a/brane-prx/src/main.rs
+++ b/brane-prx/src/main.rs
@@ -147,7 +147,7 @@ async fn main() {
 
     // Run the server
     info!("Reading to accept new connections @ '{}'...", bind_addr);
-    match warp::serve(filter).try_bind_with_graceful_shutdown(bind_addr, async {
+    let handle = warp::serve(filter).try_bind_with_graceful_shutdown(bind_addr, async {
         // Register a SIGTERM handler to be Docker-friendly
         let mut handler: Signal = match signal(SignalKind::terminate()) {
             Ok(handler) => handler,
@@ -163,7 +163,9 @@ async fn main() {
         // Wait until we receive such a signal after which we terminate the server
         handler.recv().await;
         info!("Received SIGTERM, shutting down gracefully...");
-    }) {
+    });
+
+    match handle {
         Ok((addr, srv)) => {
             info!("Now serving @ '{addr}'");
             srv.await

--- a/brane-reg/src/check.rs
+++ b/brane-reg/src/check.rs
@@ -174,7 +174,7 @@ async fn check_data_or_result(name: DataName, body: CheckTransferRequest, contex
             };
 
             // Return it
-            return Ok(reply::with_status(Response::new(res.into()), StatusCode::OK));
+            Ok(reply::with_status(Response::new(res.into()), StatusCode::OK))
         },
 
         Ok(Some(reasons)) => {
@@ -196,11 +196,11 @@ async fn check_data_or_result(name: DataName, body: CheckTransferRequest, contex
             };
 
             // Return it
-            return Ok(reply::with_status(Response::new(res.into()), StatusCode::OK));
+            Ok(reply::with_status(Response::new(res.into()), StatusCode::OK))
         },
         Err(err) => {
             error!("{}", trace!(("Failed to consult the checker"), err));
-            return Err(warp::reject::reject());
+            Err(warp::reject::reject())
         },
     }
 }

--- a/brane-shr/src/utilities.rs
+++ b/brane-shr/src/utilities.rs
@@ -423,7 +423,6 @@ where
 
 
 /***** ADDRESS CHECKING *****/
-///
 pub fn ensure_http_schema<S>(url: S, secure: bool) -> Result<String, url::ParseError>
 where
     S: Into<String>,

--- a/brane-tsk/src/errors.rs
+++ b/brane-tsk/src/errors.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
+use std::fmt::{Display, Formatter, Result as FResult, Write};
 use std::path::PathBuf;
 
 use bollard::ClientVersion;
@@ -229,7 +229,10 @@ impl Display for PlanError {
                 f,
                 "Checker of domain '{domain}' denied plan{}",
                 if !reasons.is_empty() {
-                    format!("\n\nReasons:\n{}", reasons.iter().map(|r| format!("  - {r}\n")).collect::<String>())
+                    format!("\n\nReasons:\n{}", reasons.iter().fold(String::new(), |mut output, r| {
+                        let _ = writeln!(output, "  - {r}");
+                        output
+                    }))
                 } else {
                     String::new()
                 }

--- a/specifications/src/checking.rs
+++ b/specifications/src/checking.rs
@@ -18,19 +18,19 @@ use reqwest::Method;
 
 /***** CONSTANTS *****/
 /// Defines the API path to fetch the checker's current list of policies.
-pub const POLICY_API_LIST_POLICIES: (Method, &'static str) = (Method::GET, "v1/management/policies");
+pub const POLICY_API_LIST_POLICIES: (Method, &str) = (Method::GET, "v1/management/policies");
 /// Defines the API path to fetch the currently active version on the checker.
-pub const POLICY_API_GET_ACTIVE_VERSION: (Method, &'static str) = (Method::GET, "v1/management/policies/active");
+pub const POLICY_API_GET_ACTIVE_VERSION: (Method, &str) = (Method::GET, "v1/management/policies/active");
 /// Defines the API path to update the currently active version on the checker.
-pub const POLICY_API_SET_ACTIVE_VERSION: (Method, &'static str) = (Method::PUT, "v1/management/policies/active");
+pub const POLICY_API_SET_ACTIVE_VERSION: (Method, &str) = (Method::PUT, "v1/management/policies/active");
 /// Defines the API path to add a new policy version to the checker.
-pub const POLICY_API_ADD_VERSION: (Method, &'static str) = (Method::POST, "v1/management/policies");
+pub const POLICY_API_ADD_VERSION: (Method, &str) = (Method::POST, "v1/management/policies");
 /// Defines the API path to fetch a policy's body from a checker.
 pub const POLICY_API_GET_VERSION: (Method, fn(i64) -> String) = (Method::GET, |version: i64| format!("v1/management/policies/{version}"));
 
 /// Defines the API path to check if a workflow as a whole is permitted to be executed.
-pub const DELIBERATION_API_WORKFLOW: (Method, &'static str) = (Method::POST, "v1/deliberation/execute-workflow");
+pub const DELIBERATION_API_WORKFLOW: (Method, &str) = (Method::POST, "v1/deliberation/execute-workflow");
 /// Defines the API path to check if a task in a workflow is permitted to be executed.
-pub const DELIBERATION_API_EXECUTE_TASK: (Method, &'static str) = (Method::POST, "v1/deliberation/execute-task");
+pub const DELIBERATION_API_EXECUTE_TASK: (Method, &str) = (Method::POST, "v1/deliberation/execute-task");
 /// Defines the API path to check if a dataset in a workflow is permitted to be transferred.
-pub const DELIBERATION_API_TRANSFER_DATA: (Method, &'static str) = (Method::POST, "v1/deliberation/access-data");
+pub const DELIBERATION_API_TRANSFER_DATA: (Method, &str) = (Method::POST, "v1/deliberation/access-data");

--- a/specifications/src/common.rs
+++ b/specifications/src/common.rs
@@ -34,9 +34,6 @@ pub struct Parameter {
 }
 
 impl Parameter {
-    ///
-    ///
-    ///
     pub fn new(
         name: String,
         data_type: String,
@@ -68,9 +65,6 @@ pub struct Function {
 }
 
 impl Function {
-    ///
-    ///
-    ///
     pub fn new(
         parameters: Vec<Parameter>,
         pattern: Option<CallPattern>,
@@ -99,9 +93,6 @@ pub struct CallPattern {
 }
 
 impl CallPattern {
-    ///
-    ///
-    ///
     pub fn new(
         prefix: Option<String>,
         infix: Option<Vec<String>>,
@@ -123,9 +114,6 @@ pub struct Type {
 }
 
 impl Type {
-    ///
-    ///
-    ///
     pub fn new(
         name: String,
         properties: Vec<Property>,
@@ -151,9 +139,6 @@ pub struct Property {
 }
 
 impl Property {
-    ///
-    ///
-    ///
     pub fn new(
         name: String,
         data_type: String,
@@ -172,9 +157,6 @@ impl Property {
         }
     }
 
-    ///
-    ///
-    ///
     pub fn new_quick(
         name: &str,
         data_type: &str,
@@ -189,9 +171,6 @@ impl Property {
         }
     }
 
-    ///
-    ///
-    ///
     pub fn into_parameter(self) -> Parameter {
         Parameter::new(self.name, self.data_type, self.optional, self.default, None)
     }
@@ -315,9 +294,6 @@ impl Display for CastError {
 impl std::error::Error for CastError {}
 
 impl Value {
-    ///
-    ///
-    ///
     pub fn from_json(value: &JValue) -> Self {
         match value {
             JValue::Null => Value::Unit,
@@ -371,9 +347,6 @@ impl Value {
     }
     /*******/
 
-    ///
-    ///
-    ///
     pub fn as_bool(&self) -> Result<bool, CastError> {
         if let Value::Boolean(b) = self {
             Ok(*b)
@@ -382,9 +355,6 @@ impl Value {
         }
     }
 
-    ///
-    ///
-    ///
     pub fn as_f64(&self) -> Result<f64, CastError> {
         if let Value::Real(f) = self {
             Ok(*f)
@@ -393,9 +363,6 @@ impl Value {
         }
     }
 
-    ///
-    ///
-    ///
     pub fn as_i64(&self) -> Result<i64, CastError> {
         if let Value::Integer(i) = self {
             Ok(*i)
@@ -404,9 +371,6 @@ impl Value {
         }
     }
 
-    ///
-    ///
-    ///
     pub fn as_string(&self) -> Result<String, CastError> {
         if let Value::Unicode(s) = self {
             Ok(s.clone())
@@ -415,9 +379,6 @@ impl Value {
         }
     }
 
-    ///
-    ///
-    ///
     pub fn as_json(&self) -> JValue {
         use Value::*;
         match self {
@@ -487,9 +448,6 @@ impl Display for Value {
 }
 
 impl PartialEq for Value {
-    ///
-    ///
-    ///
     fn eq(
         &self,
         other: &Self,
@@ -511,9 +469,6 @@ impl PartialEq for Value {
 }
 
 impl PartialOrd for Value {
-    ///
-    ///
-    ///
     fn partial_cmp(
         &self,
         other: &Self,
@@ -591,9 +546,6 @@ pub struct Variable {
 }
 
 impl Variable {
-    ///
-    ///
-    ///
     pub fn new(
         name: String,
         data_type: String,
@@ -608,9 +560,6 @@ impl Variable {
         }
     }
 
-    ///
-    ///
-    ///
     pub fn as_pointer(&self) -> Value {
         Value::Pointer {
             data_type: self.data_type.clone(),

--- a/specifications/src/package.rs
+++ b/specifications/src/package.rs
@@ -556,7 +556,7 @@ impl PackageIndex {
             if package.version >= latest_package.0 {
                 // It is; update the version to point to the latest version of this package
                 latest_package.0 = package.version;
-                latest_package.1 = key.clone();
+                latest_package.1.clone_from(key);
             }
         }
 


### PR DESCRIPTION
Okay, I was able to fix all but two clippy warnings.
The last two remaining are about the context struct in planner, it contains a state element that has a too complex type. I could alias the type to get it more managable, but I do not know what it does to be honest. @Lut99, could you alias them or ignore them?

Furthermore, @lut99 if you prefer to keep some lints in their old form with an ignore, add a comment and I will change it back with an allow directive.

With this merged, we are one step closer to having working and useful CI again.