### PR TITLE
fix: Set openssl version

### DIFF
--- a/brane-cc/Cargo.toml
+++ b/brane-cc/Cargo.toml
@@ -32,4 +32,5 @@ expanduser = "1.2.2"
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
+version = "0.9"
 features = ["vendored"]

--- a/brane-cli-c/Cargo.toml
+++ b/brane-cli-c/Cargo.toml
@@ -34,4 +34,5 @@ specifications = { path = "../specifications" }
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
+version = "0.9"
 features = ["vendored"]

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -76,6 +76,7 @@ specifications = { path = "../specifications" }
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
+version = "0.9"
 features = ["vendored"]
 
 

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -49,6 +49,7 @@ specifications = { path = "../specifications" }
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
+version = "0.9"
 features = ["vendored"]
 
 


### PR DESCRIPTION
Unfortunately, we now have to set the version of openssl if we want to enable the vendored feature. Without this change we currently cannot compile. I am open to other suggestions.