### PR TITLE
chore: Move to yaml_rust2 and serde_yml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +37,12 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -119,6 +137,12 @@ dependencies = [
  "blake2-rfc",
  "scoped_threadpool",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayref"
@@ -514,7 +538,7 @@ dependencies = [
  "scylla",
  "serde",
  "serde_json",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "specifications 3.0.0",
  "tempfile",
  "time 0.3.34",
@@ -600,7 +624,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "serde",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "specifications 3.0.0",
  "tokio",
  "x509-parser",
@@ -660,7 +684,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.6.1",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "specifications 3.0.0",
  "tar",
  "tempfile",
@@ -727,7 +751,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "shlex",
  "specifications 3.0.0",
  "srv",
@@ -878,7 +902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "specifications 3.0.0",
  "tokio",
  "tokio-stream",
@@ -902,12 +926,12 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "specifications 3.0.0",
  "subprocess",
  "tokio",
  "tonic",
- "yaml-rust",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -931,7 +955,7 @@ dependencies = [
  "reqwest_cookie_store",
  "serde",
  "serde_json",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "specifications 3.0.0",
 ]
 
@@ -1011,7 +1035,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "specifications 3.0.0",
  "tempfile",
  "tokio",
@@ -1109,7 +1133,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "sha2",
  "shellexpand",
  "specifications 3.0.0",
@@ -2275,7 +2299,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -2293,6 +2317,19 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "headers"
@@ -2618,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2686,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -2812,6 +2849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
+
+[[package]]
 name = "libz-sys"
 version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,9 +2924,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -4040,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -4198,9 +4241,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -4217,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4228,11 +4271,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -4324,7 +4367,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4374,11 +4417,28 @@ version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ce6afeda22f0b55dde2c34897bce76a629587348480384231205c14b59a01f"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "libyml",
+ "log",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -4586,7 +4646,7 @@ dependencies = [
  "serde_repr",
  "serde_test",
  "serde_with 3.6.1",
- "serde_yaml 0.9.32",
+ "serde_yml",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "tonic",
@@ -5207,7 +5267,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5220,7 +5280,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5923,6 +5983,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/brane-api/Cargo.toml
+++ b/brane-api/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { version = "0.11", features = ["rustls-tls-manual-roots"] }
 scylla = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tempfile = "3.2"
 time = "0.3"
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "signal"] }

--- a/brane-cfg/Cargo.toml
+++ b/brane-cfg/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4"
 rustls = "0.21"
 rustls-pemfile = "1.0.1"
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tokio = { version = "1", features = [] }
 x509-parser = "0.15"
 

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -51,7 +51,7 @@ semver = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3.0"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tar = "0.4"
 tempfile = "3.2"
 tokio = { version = "1", features = ["full"] }

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -36,7 +36,7 @@ rand = "0.8"
 reqwest = { version = "0.11" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 shlex = "1.1.0"
 tempfile = "3.3.0"
 tokio = { version = "1", features = [] }

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -23,7 +23,7 @@ reqwest = { version = "0.11", features = ["rustls-tls-manual-roots","json","stre
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_json_any_key = "2.0.0"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "signal"] }
 tokio-stream = "0.1"
 tonic = "0.11"

--- a/brane-let/Cargo.toml
+++ b/brane-let/Cargo.toml
@@ -19,12 +19,12 @@ log = "0.4"
 reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 # socksx = { git = "https://github.com/onnovalkering/socksx" }
 subprocess = "0.2"
 tokio = { version = "1", features = ["full", "time"] }
 tonic = "0.11"
-yaml-rust = "0.4"
+yaml-rust = { version = "0.8", package = "yaml-rust2" }
 
 brane-ast = { path = "../brane-ast" }
 brane-exe = { path = "../brane-exe" }

--- a/brane-oas/Cargo.toml
+++ b/brane-oas/Cargo.toml
@@ -18,5 +18,5 @@ reqwest = { version = "0.11", features = ["json", "cookies", "blocking"] }
 reqwest_cookie_store = "0.2"
 serde = "1"
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 specifications = { path = "../specifications" }

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = "0.11"
 rustls = "0.21"
 serde = { version = "1", features = ["rc"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tempfile = "3.2"
 tokio = { version = "1", features = ["rt","rt-multi-thread","macros","io-util", "signal"] }
 tokio-rustls = "0.24"

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -34,7 +34,7 @@ rand = "0.8"
 reqwest = { version = "0.11", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
 serde = "1"
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 sha2 = "0.10.6"
 tokio = "1"
 tokio-tar = "0.3.0"

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1"
 serde_repr = "0.1"
 serde_test = "1.0"
 serde_with = "3.0"
-serde_yaml = "0.9"
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
 strum = "0.24"
 strum_macros = "0.24"
 tonic = "0.11"


### PR DESCRIPTION
Old deps are no longer maintained. Swapping them still compiles.

Fixes: #72