### PR TITLE
chore: Update Cargo minimal versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
+source = "git+https://github.com/epi-project/brane?branch=develop#5944e993ff4c0521e065218e7d1feb60ef0e099b"
 dependencies = [
  "brane-dsl 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "brane-shr 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
+source = "git+https://github.com/epi-project/brane?branch=develop#5944e993ff4c0521e065218e7d1feb60ef0e099b"
 dependencies = [
  "brane-shr 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "bytes",
@@ -868,7 +868,7 @@ dependencies = [
 [[package]]
 name = "brane-exe"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
+source = "git+https://github.com/epi-project/brane?branch=develop#5944e993ff4c0521e065218e7d1feb60ef0e099b"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -1088,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
+source = "git+https://github.com/epi-project/brane?branch=develop#5944e993ff4c0521e065218e7d1feb60ef0e099b"
 dependencies = [
  "async-compression 0.3.15",
  "console",
@@ -1199,9 +1199,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
+checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
 
 [[package]]
 name = "cfg-if"
@@ -1880,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"
@@ -4462,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
+source = "git+https://github.com/epi-project/brane?branch=develop#5944e993ff4c0521e065218e7d1feb60ef0e099b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -70,47 +70,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -118,15 +119,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "argon2rs"
@@ -184,7 +185,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.34",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -225,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.6"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
+checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
 dependencies = [
  "flate2",
  "futures-core",
@@ -238,13 +239,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -266,19 +267,25 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -294,7 +301,7 @@ dependencies = [
 [[package]]
 name = "audit-logger"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "async-trait",
  "auth-resolver",
@@ -312,7 +319,7 @@ dependencies = [
 [[package]]
 name = "auth-resolver"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "async-trait",
  "serde",
@@ -321,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
@@ -337,8 +344,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -347,7 +354,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -363,7 +370,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -377,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
  "futures-core",
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "instant",
  "pin-project",
  "rand 0.8.5",
@@ -386,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -418,6 +425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,9 +444,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitmaps"
@@ -487,7 +500,7 @@ dependencies = [
  "futures-util",
  "hex",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "hyperlocal",
  "log",
  "pin-project-lite",
@@ -523,7 +536,7 @@ dependencies = [
  "brane-shr 3.0.0",
  "bytes",
  "chrono",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dotenvy",
  "enum-debug",
  "env_logger",
@@ -534,19 +547,19 @@ dependencies = [
  "log",
  "prost",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "scylla",
  "serde",
  "serde_json",
  "serde_yml",
  "specifications 3.0.0",
  "tempfile",
- "time 0.3.34",
+ "time 0.3.36",
  "tokio",
  "tokio-stream",
  "tokio-tar",
  "tokio-util",
- "uuid 1.7.0",
+ "uuid 1.9.1",
  "warp",
 ]
 
@@ -567,13 +580,13 @@ dependencies = [
  "serde_json_any_key",
  "specifications 3.0.0",
  "strum 0.25.0",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#9a8755eb14a35d50a4d6fd4128032825a2879956"
+source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
 dependencies = [
  "brane-dsl 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "brane-shr 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
@@ -588,7 +601,7 @@ dependencies = [
  "serde_json_any_key",
  "specifications 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "strum 0.25.0",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -599,7 +612,7 @@ dependencies = [
  "brane-dsl 3.0.0",
  "brane-shr 3.0.0",
  "brane-tsk",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dotenvy",
  "enum-debug",
  "expanduser",
@@ -621,8 +634,8 @@ dependencies = [
  "brane-shr 3.0.0",
  "enum-debug",
  "log",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_yml",
  "specifications 3.0.0",
@@ -635,7 +648,7 @@ name = "brane-cli"
 version = "3.0.0"
 dependencies = [
  "anyhow",
- "async-compression 0.4.6",
+ "async-compression 0.4.11",
  "async-trait",
  "base64 0.21.7",
  "bollard",
@@ -648,7 +661,7 @@ dependencies = [
  "brane-shr 3.0.0",
  "brane-tsk",
  "chrono",
- "clap 4.5.2",
+ "clap 4.5.7",
  "console",
  "cwl",
  "dialoguer 0.10.4",
@@ -665,7 +678,7 @@ dependencies = [
  "graphql_client",
  "human-panic",
  "humanlog",
- "hyper",
+ "hyper 0.14.29",
  "indicatif",
  "lazy_static",
  "log",
@@ -676,14 +689,14 @@ dependencies = [
  "path-clean",
  "prettytable-rs",
  "rand 0.8.5",
- "reqwest",
- "rustls",
+ "reqwest 0.11.27",
+ "rustls 0.21.12",
  "rustyline",
  "rustyline-derive",
- "semver 1.0.22",
+ "semver 1.0.23",
  "serde",
  "serde_json",
- "serde_with 3.6.1",
+ "serde_with 3.8.1",
  "serde_yml",
  "specifications 3.0.0",
  "tar",
@@ -694,7 +707,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "url",
- "uuid 1.7.0",
+ "uuid 1.9.1",
  "x509-parser",
 ]
 
@@ -726,7 +739,7 @@ dependencies = [
  "brane-cfg",
  "brane-shr 3.0.0",
  "brane-tsk",
- "clap 4.5.2",
+ "clap 4.5.7",
  "console",
  "dialoguer 0.11.0",
  "diesel",
@@ -748,7 +761,7 @@ dependencies = [
  "openssl-sys",
  "policy",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_yml",
@@ -770,7 +783,7 @@ dependencies = [
  "brane-prx",
  "brane-shr 3.0.0",
  "brane-tsk",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dashmap 5.5.3",
  "dotenvy",
  "enum-debug",
@@ -779,7 +792,7 @@ dependencies = [
  "futures-util",
  "log",
  "prost",
- "reqwest",
+ "reqwest 0.11.27",
  "serde_json",
  "serde_json_any_key",
  "specifications 3.0.0",
@@ -801,7 +814,7 @@ dependencies = [
  "nom_locate",
  "rand 0.8.5",
  "regex",
- "semver 1.0.22",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "specifications 3.0.0",
@@ -811,7 +824,7 @@ dependencies = [
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#9a8755eb14a35d50a4d6fd4128032825a2879956"
+source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
 dependencies = [
  "brane-shr 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "bytes",
@@ -822,7 +835,7 @@ dependencies = [
  "nom_locate",
  "rand 0.8.5",
  "regex",
- "semver 1.0.22",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "specifications 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
@@ -849,13 +862,13 @@ dependencies = [
  "simplelog",
  "specifications 3.0.0",
  "tokio",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
 name = "brane-exe"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#9a8755eb14a35d50a4d6fd4128032825a2879956"
+source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -872,7 +885,7 @@ dependencies = [
  "serde_json",
  "specifications 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "tokio",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -888,7 +901,7 @@ dependencies = [
  "brane-shr 3.0.0",
  "brane-tsk",
  "chrono",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dashmap 4.0.2",
  "deliberation",
  "dotenvy",
@@ -896,9 +909,9 @@ dependencies = [
  "env_logger",
  "error-trace",
  "futures-util",
- "hyper",
+ "hyper 0.14.29",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_json_any_key",
@@ -918,12 +931,12 @@ dependencies = [
  "brane-ast 3.0.0",
  "brane-exe 3.0.0",
  "brane-oas",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dotenvy",
  "env_logger",
  "libc",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_yml",
@@ -951,7 +964,7 @@ dependencies = [
  "maplit",
  "openapiv3",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "reqwest_cookie_store",
  "serde",
  "serde_json",
@@ -969,7 +982,7 @@ dependencies = [
  "brane-prx",
  "brane-shr 3.0.0",
  "brane-tsk",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dotenvy",
  "error-trace",
  "futures-util",
@@ -977,7 +990,7 @@ dependencies = [
  "log",
  "parking_lot",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "serde_json",
  "specifications 3.0.0",
  "tokio",
@@ -994,20 +1007,20 @@ dependencies = [
  "brane-cfg",
  "brane-shr 3.0.0",
  "brane-tsk",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dotenvy",
  "env_logger",
  "error-trace",
  "log",
  "never-say-never",
- "reqwest",
- "rustls",
+ "reqwest 0.11.27",
+ "rustls 0.21.12",
  "serde",
  "serde_json",
  "socksx",
  "specifications 3.0.0",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tonic",
  "url",
  "warp",
@@ -1023,7 +1036,7 @@ dependencies = [
  "brane-exe 3.0.0",
  "brane-shr 3.0.0",
  "brane-tsk",
- "clap 4.5.2",
+ "clap 4.5.7",
  "deliberation",
  "dotenvy",
  "enum-debug",
@@ -1031,15 +1044,15 @@ dependencies = [
  "error-trace",
  "k8s-openapi",
  "log",
- "reqwest",
- "rustls",
+ "reqwest 0.11.27",
+ "rustls 0.21.12",
  "serde",
  "serde_json",
  "serde_yml",
  "specifications 3.0.0",
  "tempfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "warp",
 ]
@@ -1054,7 +1067,7 @@ dependencies = [
  "enum-debug",
  "fs2",
  "futures-util",
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "hex",
  "humanlog",
  "indicatif",
@@ -1062,7 +1075,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "sha2",
  "specifications 3.0.0",
  "tempfile",
@@ -1075,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#9a8755eb14a35d50a4d6fd4128032825a2879956"
+source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
 dependencies = [
  "async-compression 0.3.15",
  "console",
@@ -1089,9 +1102,8 @@ dependencies = [
  "log",
  "num-derive 0.3.3",
  "num-traits",
- "rdkafka",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "sha2",
  "specifications 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "tokio",
@@ -1113,7 +1125,7 @@ dependencies = [
  "brane-exe 3.0.0",
  "brane-shr 3.0.0",
  "chrono",
- "clap 4.5.2",
+ "clap 4.5.7",
  "console",
  "dialoguer 0.11.0",
  "dirs-2",
@@ -1122,7 +1134,7 @@ dependencies = [
  "graphql_client",
  "hex-literal",
  "humanlog",
- "hyper",
+ "hyper 0.14.29",
  "indicatif",
  "lazy_static",
  "log",
@@ -1130,7 +1142,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_yml",
@@ -1141,7 +1153,7 @@ dependencies = [
  "tokio-tar",
  "tokio-util",
  "tonic",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -1163,15 +1175,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecount"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "byteorder"
@@ -1181,15 +1193,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 
 [[package]]
 name = "cfg-if"
@@ -1199,9 +1211,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1209,7 +1221,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1229,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1239,33 +1251,33 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clipboard-win"
@@ -1279,19 +1291,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -1332,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "const_format"
@@ -1380,7 +1383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "percent-encoding",
- "time 0.3.34",
+ "time 0.3.36",
  "version_check",
 ]
 
@@ -1413,7 +1416,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.34",
+ "time 0.3.36",
  "url",
 ]
 
@@ -1444,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1497,7 +1500,7 @@ dependencies = [
  "log",
  "serde",
  "serde_with 1.14.0",
- "serde_yaml 0.8.26",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -1512,12 +1515,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
 ]
 
 [[package]]
@@ -1536,16 +1539,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.52",
+ "strsim 0.11.1",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1561,13 +1564,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core 0.20.9",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1587,7 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1595,14 +1598,14 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deliberation"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "brane-ast 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "brane-exe 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
@@ -1611,7 +1614,7 @@ dependencies = [
  "serde",
  "serde_json",
  "transform",
- "uuid 1.7.0",
+ "uuid 1.9.1",
  "workflow 0.3.0",
 ]
 
@@ -1677,32 +1680,33 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.4"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
+checksum = "62d6dcd069e7b5fe49a302411f759d4cf1cf2c27fe798ef46fb8baefc053dd2b"
 dependencies = [
  "diesel_derives",
  "libsqlite3-sys",
- "time 0.3.34",
+ "time 0.3.36",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.2"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
+checksum = "59de76a222c2b8059f789cbe07afbfd8deb8c31dd0bc2a21f85e256c1def8259"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "diesel_migrations"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -1711,11 +1715,11 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1777,7 +1781,7 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.4.4",
+ "redox_users 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1788,7 +1792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.4",
+ "redox_users 0.4.5",
  "winapi",
 ]
 
@@ -1800,13 +1804,13 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1829,9 +1833,23 @@ dependencies = [
  "console",
  "hex",
  "indicatif",
- "reqwest",
+ "reqwest 0.11.27",
  "sha2",
  "url",
+]
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0892a17df262a24294c382f0d5997571006e7a4348b4327557c4ff1cd4a8bccc"
+dependencies = [
+ "darling 0.20.9",
+ "either",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1846,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "eflint-to-json"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "async-recursion",
  "console",
@@ -1855,16 +1873,16 @@ dependencies = [
  "hex-literal",
  "indicatif",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "sha2",
  "tokio",
 ]
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encode_unicode"
@@ -1880,9 +1898,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1931,9 +1949,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1952,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "error-trace"
 version = "1.1.1"
-source = "git+https://github.com/Lut99/error-trace-rs#f297499c41cb33fc287d931eec748fde6bc9b164"
+source = "git+https://github.com/Lut99/error-trace-rs#58bd7e59aa6c81a732e6df1a60118894f60b5633"
 
 [[package]]
 name = "expanduser"
@@ -1989,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fd-lock"
@@ -2018,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -2146,7 +2164,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2202,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2215,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "graphql-introspection-query"
@@ -2289,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -2307,6 +2325,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,9 +2351,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2328,7 +2365,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2369,6 +2406,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2437,6 +2480,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-serde"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -2470,8 +2536,8 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml 0.8.10",
- "uuid 1.7.0",
+ "toml",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -2494,17 +2560,17 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2517,6 +2583,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,10 +2610,27 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
- "rustls",
+ "hyper 0.14.29",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.23.10",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -2536,7 +2639,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2549,10 +2652,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2563,7 +2702,7 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.29",
  "pin-project",
  "tokio",
 ]
@@ -2660,7 +2799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -2679,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -2704,6 +2843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +2862,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2738,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.2.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
@@ -2817,32 +2971,31 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.4.1",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -2856,12 +3009,11 @@ checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.15"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2874,15 +3026,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2897,9 +3049,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
 ]
@@ -2930,28 +3082,28 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "migrations_internals"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -2982,9 +3134,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -3028,11 +3180,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -3076,7 +3227,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg-if",
  "libc",
  "memoffset",
@@ -3111,11 +3262,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3145,7 +3295,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3159,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -3178,32 +3328,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -3215,7 +3344,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3235,9 +3364,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
 ]
@@ -3266,7 +3395,7 @@ dependencies = [
  "indexmap 1.9.3",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -3275,7 +3404,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3292,7 +3421,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3303,18 +3432,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.3+3.2.1"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -3340,13 +3469,13 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.7.0"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
  "serde",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3355,9 +3484,9 @@ version = "3.0.0"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3365,15 +3494,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3384,11 +3513,11 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pem"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -3415,14 +3544,14 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -3439,7 +3568,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "policy"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3536,18 +3665,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3555,22 +3684,22 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
@@ -3603,9 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -3707,7 +3836,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3738,37 +3867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdkafka"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88383df3a85a38adfa2aa447d3ab6eb9cedcb49613adcf18e7e7ebb3b62e9b03"
-dependencies = [
- "futures-channel",
- "futures-util",
- "libc",
- "log",
- "rdkafka-sys",
- "serde",
- "serde_derive",
- "serde_json",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "rdkafka-sys"
-version = "4.7.0+2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
-dependencies = [
- "cmake",
- "libc",
- "libz-sys",
- "num_enum 0.5.11",
- "pkg-config",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "reasonerconn"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3789,7 +3887,7 @@ dependencies = [
  "enum-debug",
  "log",
  "policy",
- "reqwest",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "state-resolver",
@@ -3823,6 +3921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3847,20 +3954,20 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3870,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3881,15 +3988,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -3898,12 +4005,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -3913,16 +4020,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -3930,7 +4037,51 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.27.2",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3942,7 +4093,7 @@ dependencies = [
  "bytes",
  "cookie 0.15.2",
  "cookie_store 0.15.1",
- "reqwest",
+ "reqwest 0.11.27",
  "url",
 ]
 
@@ -3954,7 +4105,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -3975,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -3999,11 +4150,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4012,14 +4163,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4032,6 +4196,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4042,10 +4222,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
+name = "rustls-webpki"
+version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rustyline"
@@ -4149,7 +4340,7 @@ dependencies = [
  "histogram",
  "itertools 0.11.0",
  "lz4_flex",
- "num_enum 0.6.1",
+ "num_enum",
  "rand 0.8.5",
  "rand_pcg",
  "scylla-cql",
@@ -4162,7 +4353,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -4175,12 +4366,12 @@ dependencies = [
  "byteorder",
  "bytes",
  "lz4_flex",
- "num_enum 0.6.1",
+ "num_enum",
  "scylla-macros",
  "snap",
  "thiserror",
  "tokio",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -4189,19 +4380,19 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb6085ff9c3fd7e5163826901d39164ab86f11bdca16b2f766a00c528ff9cef9"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4210,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4229,9 +4420,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "semver-parser"
@@ -4266,14 +4457,14 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -4293,20 +4484,20 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -4354,16 +4545,16 @@ dependencies = [
  "indexmap 1.9.3",
  "serde",
  "serde_json",
- "time 0.3.34",
+ "time 0.3.36",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.6.1"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4371,8 +4562,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.6.1",
- "time 0.3.34",
+ "serde_with_macros 3.8.1",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -4389,14 +4580,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.1"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4409,19 +4600,6 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
-dependencies = [
- "indexmap 2.2.6",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4501,9 +4679,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -4517,7 +4695,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.34",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -4529,7 +4707,7 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time 0.3.34",
+ "time 0.3.36",
  "winapi",
 ]
 
@@ -4541,7 +4719,7 @@ checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.34",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -4565,9 +4743,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smartstring"
@@ -4588,9 +4766,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4604,7 +4782,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "clap 4.5.2",
+ "clap 4.5.7",
  "dotenv",
  "env_logger",
  "futures",
@@ -4639,24 +4817,24 @@ dependencies = [
  "parking_lot",
  "prost",
  "prost-types",
- "reqwest",
- "semver 1.0.22",
+ "reqwest 0.11.27",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "serde_repr",
  "serde_test",
- "serde_with 3.6.1",
+ "serde_with 3.8.1",
  "serde_yml",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "tonic",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#9a8755eb14a35d50a4d6fd4128032825a2879956"
+source = "git+https://github.com/epi-project/brane?branch=develop#85a379b917ba229f8e99df515234b682969c028c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4672,18 +4850,18 @@ dependencies = [
  "parking_lot",
  "prost",
  "prost-types",
- "reqwest",
- "semver 1.0.22",
+ "reqwest 0.11.27",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "serde_repr",
  "serde_test",
- "serde_with 3.6.1",
- "serde_yaml 0.9.32",
+ "serde_with 3.8.1",
+ "serde_yml",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "tonic",
- "uuid 1.7.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -4695,7 +4873,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "srv"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "audit-logger",
  "auth-resolver",
@@ -4714,7 +4892,7 @@ dependencies = [
  "state-resolver",
  "tokio",
  "tokio-scoped",
- "uuid 1.7.0",
+ "uuid 1.9.1",
  "warp",
  "workflow 0.1.0",
 ]
@@ -4731,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "state-resolver"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "async-trait",
  "serde",
@@ -4813,9 +4991,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -4874,7 +5052,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4886,6 +5064,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4900,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4914,6 +5098,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -4950,9 +5140,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",
@@ -5002,22 +5192,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5037,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -5049,7 +5239,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.17",
+ "time-macros 0.2.18",
 ]
 
 [[package]]
@@ -5070,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5093,9 +5283,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5108,9 +5298,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5137,13 +5327,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5162,7 +5352,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.10",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5178,9 +5379,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5204,9 +5405,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
@@ -5216,47 +5417,34 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.6",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -5268,22 +5456,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.6",
- "serde",
- "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -5297,10 +5484,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5365,7 +5552,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5390,14 +5577,14 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5461,9 +5648,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -5481,12 +5668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,9 +5675,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
@@ -5511,9 +5692,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -5523,11 +5704,11 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "rand 0.8.5",
  "serde",
 ]
@@ -5577,29 +5758,27 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "log",
  "mime",
  "mime_guess",
  "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tower-service",
@@ -5639,7 +5818,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -5673,7 +5852,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5725,11 +5904,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5763,7 +5942,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -5781,7 +5960,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -5801,17 +5980,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -5822,9 +6002,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5834,9 +6014,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5846,9 +6026,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5858,9 +6044,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5870,9 +6056,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5882,9 +6068,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5894,15 +6080,24 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -5918,9 +6113,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "workflow"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a81affbe6cc0fcd61e3b5e15e02df709f7ebfe3b"
+source = "git+https://github.com/epi-project/policy-reasoner#ee783def8ba6a80193244abdd12de7bad18b5377"
 dependencies = [
  "brane-ast 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
  "brane-exe 3.0.0 (git+https://github.com/epi-project/brane?branch=develop)",
@@ -5943,7 +6148,7 @@ dependencies = [
  "clap 2.34.0",
  "log",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "simple_logger",
  "walkdir",
 ]
@@ -5962,7 +6167,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.34",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -6013,11 +6218,11 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",

--- a/brane-api/Cargo.toml
+++ b/brane-api/Cargo.toml
@@ -6,34 +6,34 @@ edition = "2018"
 
 [dependencies]
 async-compression = { version = "0.3.15", features = ["tokio","gzip"] }
-bytes = "1"
-chrono = "0.4"
-clap = { version = "4.0.24", features = ["derive","env"] }
+bytes = "1.2.0"
+chrono = "0.4.23"
+clap = { version = "4.4.0", features = ["derive","env"] }
 dotenvy = "0.15"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-env_logger = "0.10"
+env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-futures = "0.3"
-juniper = "0.15"
-juniper_warp = "0.7"
+futures = "0.3.24"
+juniper = "0.15.7"
+juniper_warp = "0.7.0"
 # k8s-openapi = { version = "0.14", default-features = false, features = ["v1_23"] }
-log = "0.4"
-prost = "0.12"
+log = "0.4.17"
+prost = "0.12.0"
 rand = "0.8.5"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
-reqwest = { version = "0.11", features = ["rustls-tls-manual-roots"] }
-scylla = "0.12"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+reqwest = { version = "0.11.27", features = ["rustls-tls-manual-roots"] }
+scylla = "0.12.0"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.87"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-tempfile = "3.2"
-time = "0.3"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "signal"] }
-tokio-stream = "0.1"
+tempfile = "3.3.0"
+time = "0.3.16"
+tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
+tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"
-tokio-util = { version = "0.7", features = ["codec"] }
-uuid = { version = "1.7", features = ["serde", "v4"] }
-warp = "0.3"
+tokio-util = { version = "0.7.1", features = ["codec"] }
+uuid = { version = "1.7.0", features = ["serde", "v4"] }
+warp = "0.3.0"
 
 brane-cfg      = { path = "../brane-cfg" }
 brane-prx      = { path = "../brane-prx" }

--- a/brane-api/Cargo.toml
+++ b/brane-api/Cargo.toml
@@ -17,16 +17,16 @@ futures = "0.3.24"
 juniper = "0.15.7"
 juniper_warp = "0.7.0"
 # k8s-openapi = { version = "0.14", default-features = false, features = ["v1_23"] }
-log = "0.4.17"
+log = "0.4.21"
 prost = "0.12.0"
 rand = "0.8.5"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
 reqwest = { version = "0.11.27", features = ["rustls-tls-manual-roots"] }
 scylla = "0.12.0"
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-tempfile = "3.3.0"
+tempfile = "3.10.1"
 time = "0.3.16"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-stream = "0.1.6"

--- a/brane-ast/Cargo.toml
+++ b/brane-ast/Cargo.toml
@@ -9,10 +9,10 @@ console = "0.15.5"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 im = "15.1.0"
 lazy_static = "1.4.0"
-log = "0.4.17"
+log = "0.4.21"
 rand = "0.8.5"
 num-traits = "0.2.18"
-serde = { version = "1.0.195", features = ["rc"] }
+serde = { version = "1.0.203", features = ["rc"] }
 serde_json_any_key = "2.0.0"
 strum = { version = "0.25.0", features = ["derive"] }
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/brane-ast/Cargo.toml
+++ b/brane-ast/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2021"
 authors = [ "Tim Müller" ]
 
 [dependencies]
-console = "0.15"
+console = "0.15.5"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-im = "15.1"
+im = "15.1.0"
 lazy_static = "1.4.0"
-log = "0.4"
-rand = "0.8"
-num-traits = "0.2"
-serde = { version = "1", features = ["rc"] }
+log = "0.4.17"
+rand = "0.8.5"
+num-traits = "0.2.18"
+serde = { version = "1.0.195", features = ["rc"] }
 serde_json_any_key = "2.0.0"
-strum = { version = "0.25", features = ["derive"] }
-uuid = { version = "1.7", features = ["serde", "v4"] }
+strum = { version = "0.25.0", features = ["derive"] }
+uuid = { version = "1.7.0", features = ["serde", "v4"] }
 
 brane-dsl = { path = "../brane-dsl" }
 brane-shr = { path = "../brane-shr" }

--- a/brane-cc/Cargo.toml
+++ b/brane-cc/Cargo.toml
@@ -14,7 +14,7 @@ dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 human-panic = "1.0.0"
-log = "0.4.17"
+log = "0.4.21"
 tokio = { version = "1.38.0", features = ["rt","macros"] }
 url = "2.5.0"
 
@@ -22,7 +22,7 @@ brane-ast = { path = "../brane-ast" }
 brane-dsl = { path = "../brane-dsl" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
-serde_json = "1.0.87"
+serde_json = "1.0.117"
 specifications = { path = "../specifications" }
 
 

--- a/brane-cc/Cargo.toml
+++ b/brane-cc/Cargo.toml
@@ -9,20 +9,20 @@ name = "branec"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0.24", features = ["derive","env"] }
-dotenvy = "0.15"
+clap = { version = "4.4.0", features = ["derive","env"] }
+dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-human-panic = "1.0"
-log = "0.4"
-tokio = { version = "1", features = ["rt","macros"] }
-url = "2.2"
+human-panic = "1.0.0"
+log = "0.4.17"
+tokio = { version = "1.38.0", features = ["rt","macros"] }
+url = "2.5.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-dsl = { path = "../brane-dsl" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
-serde_json = "1"
+serde_json = "1.0.87"
 specifications = { path = "../specifications" }
 
 
@@ -32,5 +32,5 @@ expanduser = "1.2.2"
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
-version = "0.9"
+version = "0.9.102"
 features = ["vendored"]

--- a/brane-cfg/Cargo.toml
+++ b/brane-cfg/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.67"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-log = "0.4.17"
+log = "0.4.21"
 rustls = "0.21.6"
 rustls-pemfile = "1.0.1"
-serde = { version = "1.0.195", features = ["derive"] }
+serde = { version = "1.0.203", features = ["derive"] }
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tokio = { version = "1.38.0", features = [] }
 x509-parser = "0.15.0"

--- a/brane-cfg/Cargo.toml
+++ b/brane-cfg/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["Onno Valkering", "Tim Müller"]
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = "0.1.67"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-log = "0.4"
-rustls = "0.21"
+log = "0.4.17"
+rustls = "0.21.6"
 rustls-pemfile = "1.0.1"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.195", features = ["derive"] }
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-tokio = { version = "1", features = [] }
-x509-parser = "0.15"
+tokio = { version = "1.38.0", features = [] }
+x509-parser = "0.15.0"
 
 brane-shr      = { path = "../brane-shr" }
 specifications = { path = "../specifications" }

--- a/brane-cli-c/Cargo.toml
+++ b/brane-cli-c/Cargo.toml
@@ -16,9 +16,9 @@ doc        = false
 console = "0.15.5"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 libc = "0.2.154"
-log = "0.4.17"
+log = "0.4.21"
 parking_lot = "0.12.1"
-serde_json = "1.0.87"
+serde_json = "1.0.117"
 tokio = "1.38.0"
 
 brane-ast = { path = "../brane-ast" }

--- a/brane-cli-c/Cargo.toml
+++ b/brane-cli-c/Cargo.toml
@@ -13,13 +13,13 @@ doc        = false
 
 
 [dependencies]
-console = "0.15"
+console = "0.15.5"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-libc = "0.2"
-log = "0.4"
-parking_lot = "0.12"
-serde_json = "1.0"
-tokio = "1.28"
+libc = "0.2.154"
+log = "0.4.17"
+parking_lot = "0.12.1"
+serde_json = "1.0.87"
+tokio = "1.38.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-cli = { path = "../brane-cli" }
@@ -34,5 +34,5 @@ specifications = { path = "../specifications" }
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
-version = "0.9"
+version = "0.9.102"
 features = ["vendored"]

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -36,7 +36,7 @@ human-panic = "1.0.0"
 hyper = "0.14.29"
 indicatif = "0.17.0"
 lazy_static = "1.4.0"
-log = "0.4.17"
+log = "0.4.21"
 names = { git = "https://github.com/Lut99/names-rs", default-features = false, features = ["rand", "three-lowercase"]}
 openapiv3 = "0.5.0"
 parking_lot = "0.12.1"
@@ -48,12 +48,12 @@ rustls = "0.21.6"
 rustyline = "11.0.0"
 rustyline-derive = "0.8.0"
 semver = "1.0.0"
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
 serde_with = "3.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tar = "0.4.21"
-tempfile = "3.3.0"
+tempfile = "3.10.1"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -9,59 +9,59 @@ name = "brane"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
+anyhow = "1.0.66"
 async-compression = { version = "0.4", features = ["tokio","gzip"] }
-async-trait = "0.1"
-base64 = "0.21"
-bollard = "0.14"
-chrono = "0.4"
-clap = { version = "4.0.24", features = ["derive","env"] }
-console = "0.15"
+async-trait = "0.1.67"
+base64 = "0.21.0"
+bollard = "0.14.0"
+chrono = "0.4.23"
+clap = { version = "4.4.0", features = ["derive","env"] }
+console = "0.15.5"
 cwl = { git = "https://github.com/onnovalkering/cwl-rs" }
-dialoguer = "0.10"
+dialoguer = "0.10.0"
 dirs-2 = "3.0.1"
-dotenvy = "0.15"
+dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-env_logger = "0.10"
+env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 filetime = "0.2.15"
-flate2 = { version = "1.0", features = ["zlib"], default-features = false }
-fs_extra = "1.2"
-futures = "0.3"
-futures-util = "0.3"
+flate2 = { version = "1.0.13", features = ["zlib"], default-features = false }
+fs_extra = "1.2.0"
+futures = "0.3.24"
+futures-util = "0.3.30"
 # git2 = { version = "0.17", features = ["vendored-libgit2"] }
-graphql_client = "0.13"
+graphql_client = "0.13.0"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-human-panic = "1.0"
-hyper = "0.14"
-indicatif = "0.17"
-lazy_static = "1.4"
-log = "0.4"
+human-panic = "1.0.0"
+hyper = "0.14.29"
+indicatif = "0.17.0"
+lazy_static = "1.4.0"
+log = "0.4.17"
 names = { git = "https://github.com/Lut99/names-rs", default-features = false, features = ["rand", "three-lowercase"]}
-openapiv3 = "0.5"
-parking_lot = "0.12"
-path-clean = "1.0"
-prettytable-rs = "0.10"
-rand = "0.8"
-reqwest = {version = "0.11", features = ["rustls-tls-manual-roots","json", "stream", "multipart"] }
-rustls = "0.21"
-rustyline = "11.0"
-rustyline-derive = "0.8"
-semver = "1.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_with = "3.0"
+openapiv3 = "0.5.0"
+parking_lot = "0.12.1"
+path-clean = "1.0.0"
+prettytable-rs = "0.10.0"
+rand = "0.8.5"
+reqwest = {version = "0.11.27", features = ["rustls-tls-manual-roots","json", "stream", "multipart"] }
+rustls = "0.21.6"
+rustyline = "11.0.0"
+rustyline-derive = "0.8.0"
+semver = "1.0.0"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.87"
+serde_with = "3.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-tar = "0.4"
-tempfile = "3.2"
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
+tar = "0.4.21"
+tempfile = "3.3.0"
+tokio = { version = "1.38.0", features = ["full"] }
+tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"
-tokio-util = { version = "0.7", features = ["codec"] }
-tonic = "0.11"
-url = "2.2"
-uuid = { version = "1.7", features = ["serde", "v4"] }
-x509-parser = "0.15"
+tokio-util = { version = "0.7.1", features = ["codec"] }
+tonic = "0.11.0"
+url = "2.5.0"
+uuid = { version = "1.7.0", features = ["serde", "v4"] }
+x509-parser = "0.15.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }
@@ -76,7 +76,7 @@ specifications = { path = "../specifications" }
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
-version = "0.9"
+version = "0.9.102"
 features = ["vendored"]
 
 

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -28,17 +28,17 @@ humantime = "2.1.0"
 human-panic = "1.0.0"
 jsonwebtoken = "9.2.0"
 lazy_static = "1.4.0"
-log = "0.4.17"
+log = "0.4.21"
 names = { git = "https://github.com/Lut99/names-rs", default-features = false, features = [ "rand", "three-lowercase" ]}
 policy = { git = "https://github.com/epi-project/policy-reasoner" }
 srv = { git = "https://github.com/epi-project/policy-reasoner" }
 rand = "0.8.5"
 reqwest = { version = "0.11.27" }
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 shlex = "1.1.0"
-tempfile = "3.3.0"
+tempfile = "3.10.1"
 tokio = { version = "1.38.0", features = [] }
 
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -9,37 +9,37 @@ name = "branectl"
 path = "src/main.rs"
 
 [dependencies]
-base64ct = "1.6"
-bollard = "0.14"
-clap = { version = "4.0.24", features = ["derive","env"] }
-console = "0.15"
-dialoguer = "0.11"
-diesel = { version = "2.1", features = ["sqlite"] }
-diesel_migrations = "2.1"
-dirs-2 = "3.0"
-dotenvy = "0.15"
+base64ct = "1.6.0"
+bollard = "0.14.0"
+clap = { version = "4.4.0", features = ["derive","env"] }
+console = "0.15.5"
+dialoguer = "0.11.0"
+diesel = { version = "2.1.0", features = ["sqlite"] }
+diesel_migrations = "2.1.0"
+dirs-2 = "3.0.0"
+dotenvy = "0.15.0"
 eflint-to-json = { git = "https://github.com/epi-project/policy-reasoner" }
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 # env_logger = "0.10"
-hex-literal = "0.4"
+hex-literal = "0.4.0"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-humantime = "2.1"
-human-panic = "1.0"
-jsonwebtoken = "9.2"
+humantime = "2.1.0"
+human-panic = "1.0.0"
+jsonwebtoken = "9.2.0"
 lazy_static = "1.4.0"
-log = "0.4"
+log = "0.4.17"
 names = { git = "https://github.com/Lut99/names-rs", default-features = false, features = [ "rand", "three-lowercase" ]}
 policy = { git = "https://github.com/epi-project/policy-reasoner" }
 srv = { git = "https://github.com/epi-project/policy-reasoner" }
-rand = "0.8"
-reqwest = { version = "0.11" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
+rand = "0.8.5"
+reqwest = { version = "0.11.27" }
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.87"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 shlex = "1.1.0"
 tempfile = "3.3.0"
-tokio = { version = "1", features = [] }
+tokio = { version = "1.38.0", features = [] }
 
 brane-cfg = { path = "../brane-cfg" }
 brane-shr = { path = "../brane-shr" }
@@ -49,13 +49,13 @@ specifications = { path = "../specifications" }
 
 # Hacky indeed but necessary to dodge OpenSSL linking, which we need to make cross-compilation _so_ much easier
 [dependencies.openssl-sys]
-version = "0.9"
+version = "0.9.102"
 features = ["vendored"]
 
 
 [build-dependencies]
 download = { git = "https://github.com/Lut99/download-rs", default-features = false, features = ["download"] }
-hex-literal = "0.4"
+hex-literal = "0.4.0"
 
 [lints.clippy]
 result_large_err = { level = "allow", priority = 1 }

--- a/brane-drv/Cargo.toml
+++ b/brane-drv/Cargo.toml
@@ -5,23 +5,23 @@ authors = { workspace = true }
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1"
-clap = { version = "4.0.24", features = ["derive","env"] }
-dashmap = "5.4"
-dotenvy = "0.15"
+async-trait = "0.1.67"
+clap = { version = "4.4.0", features = ["derive","env"] }
+dashmap = "5.4.0"
+dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-env_logger = "0.10"
+env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-futures-util = "0.3"
-log = "0.4"
-prost = "0.12"
+futures-util = "0.3.30"
+log = "0.4.17"
+prost = "0.12.0"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
-reqwest = { version = "0.11" }
-serde_json = "1"
+reqwest = { version = "0.11.27" }
+serde_json = "1.0.87"
 serde_json_any_key = "2.0.0"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "signal"] }
-tokio-stream = "0.1"
-tonic = "0.11"
+tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
+tokio-stream = "0.1.6"
+tonic = "0.11.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-drv/Cargo.toml
+++ b/brane-drv/Cargo.toml
@@ -13,11 +13,11 @@ enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"
 env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 futures-util = "0.3.30"
-log = "0.4.17"
+log = "0.4.21"
 prost = "0.12.0"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
 reqwest = { version = "0.11.27" }
-serde_json = "1.0.87"
+serde_json = "1.0.117"
 serde_json_any_key = "2.0.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-stream = "0.1.6"

--- a/brane-dsl/Cargo.toml
+++ b/brane-dsl/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 bytes = "1.2.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 itertools = "0.10.0"
-log = "0.4.17"
+log = "0.4.21"
 nom = "7.1.0"
 nom_locate = "4.1.0"
 rand = "0.8.5"
 regex = "1.5.0"
 semver = "1.0.0"
-serde = "1.0.195"
-serde_json = "1.0.87"
+serde = "1.0.203"
+serde_json = "1.0.117"
 thiserror = "1.0.40"
 
 brane-shr = { path = "../brane-shr" }

--- a/brane-dsl/Cargo.toml
+++ b/brane-dsl/Cargo.toml
@@ -5,18 +5,18 @@ authors = { workspace = true }
 edition = "2018"
 
 [dependencies]
-bytes = "1"
+bytes = "1.2.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-itertools = "0.10"
-log = "0.4"
-nom = "7.1"
-nom_locate = "4.1"
-rand = "0.8"
-regex = "1.5"
-semver = "1.0"
-serde = "1"
-serde_json = "1"
-thiserror = "1"
+itertools = "0.10.0"
+log = "0.4.17"
+nom = "7.1.0"
+nom_locate = "4.1.0"
+rand = "0.8.5"
+regex = "1.5.0"
+semver = "1.0.0"
+serde = "1.0.195"
+serde_json = "1.0.87"
+thiserror = "1.0.40"
 
 brane-shr = { path = "../brane-shr" }
 specifications = { path = "../specifications" }

--- a/brane-exe/Cargo.toml
+++ b/brane-exe/Cargo.toml
@@ -6,19 +6,19 @@ authors = [ "Tim Müller" ]
 
 [dependencies]
 async-recursion = "1.0.0"
-async-trait = "0.1"
-base64 = "0.13"
+async-trait = "0.1.67"
+base64 = "0.13.0"
 # bollard = "0.11"
-console = "0.15"
+console = "0.15.5"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 futures = "0.3.24"
 lazy_static = "1.4.0"
-log = "0.4"
-num-traits = "0.2"
-serde = "1"
-serde_json = "1"
-tokio = { version = "1.20", features = [] }
-uuid = { version = "1.7", features = ["fast-rng", "serde", "v4"] }
+log = "0.4.17"
+num-traits = "0.2.18"
+serde = "1.0.195"
+serde_json = "1.0.87"
+tokio = { version = "1.38.0", features = [] }
+uuid = { version = "1.7.0", features = ["fast-rng", "serde", "v4"] }
 
 brane-ast = { path = "../brane-ast" }
 brane-shr = { path = "../brane-shr" }

--- a/brane-exe/Cargo.toml
+++ b/brane-exe/Cargo.toml
@@ -13,10 +13,10 @@ console = "0.15.5"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 futures = "0.3.24"
 lazy_static = "1.4.0"
-log = "0.4.17"
+log = "0.4.21"
 num-traits = "0.2.18"
-serde = "1.0.195"
-serde_json = "1.0.87"
+serde = "1.0.203"
+serde_json = "1.0.117"
 tokio = { version = "1.38.0", features = [] }
 uuid = { version = "1.7.0", features = ["fast-rng", "serde", "v4"] }
 

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -5,28 +5,28 @@ authors = { workspace = true }
 edition = "2018"
 
 [dependencies]
-base64 = "0.21"
-bollard = "0.14"
-chrono = "0.4"
-clap = { version = "4.0.24", features = ["derive","env"] }
+base64 = "0.21.0"
+bollard = "0.14.0"
+chrono = "0.4.23"
+clap = { version = "4.4.0", features = ["derive","env"] }
 deliberation = { git = "https://github.com/epi-project/policy-reasoner" }
-dotenvy = "0.15"
+dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-env_logger = "0.10"
+env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-futures-util = "0.3"
-hyper = "0.14"
+futures-util = "0.3.30"
+hyper = "0.14.29"
 # kube = { version = "0.82", default_features = false, features = ["client"] }
 # k8s-openapi = { version = "0.18", default_features = false, features = ["v1_23"] }
-log = "0.4"
-reqwest = { version = "0.11", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+log = "0.4.17"
+reqwest = { version = "0.11.27", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.87"
 serde_json_any_key = "2.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "signal"] }
-tokio-stream = "0.1"
-tonic = "0.11"
+tokio = { version = "1.38.0", default-features = false, features = ["rt", "macros", "signal"] }
+tokio-stream = "0.1.6"
+tonic = "0.11.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }
@@ -37,4 +37,4 @@ brane-tsk = { path = "../brane-tsk" }
 specifications = { path = "../specifications" }
 
 [dev-dependencies]
-dashmap = "4.0"
+dashmap = "4.0.0"

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -18,10 +18,10 @@ futures-util = "0.3.30"
 hyper = "0.14.29"
 # kube = { version = "0.82", default_features = false, features = ["client"] }
 # k8s-openapi = { version = "0.18", default_features = false, features = ["v1_23"] }
-log = "0.4.17"
+log = "0.4.21"
 reqwest = { version = "0.11.27", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
 serde_json_any_key = "2.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "macros", "signal"] }

--- a/brane-let/Cargo.toml
+++ b/brane-let/Cargo.toml
@@ -9,21 +9,21 @@ name = "branelet"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
-base64 = "0.13"
-clap = { version = "4.0.24", features = ["derive","env"] }
-dotenvy = "0.15"
-env_logger = "0.10"
-libc = "0.2.118"
-log = "0.4"
-reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+anyhow = "1.0.66"
+base64 = "0.13.0"
+clap = { version = "4.4.0", features = ["derive","env"] }
+dotenvy = "0.15.0"
+env_logger = "0.10.0"
+libc = "0.2.154"
+log = "0.4.17"
+reqwest = { version = "0.11.27", features = ["json", "native-tls-vendored"] }
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.87"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 # socksx = { git = "https://github.com/onnovalkering/socksx" }
-subprocess = "0.2"
-tokio = { version = "1", features = ["full", "time"] }
-tonic = "0.11"
+subprocess = "0.2.0"
+tokio = { version = "1.38.0", features = ["full", "time"] }
+tonic = "0.11.0"
 yaml-rust = { version = "0.8", package = "yaml-rust2" }
 
 brane-ast = { path = "../brane-ast" }

--- a/brane-let/Cargo.toml
+++ b/brane-let/Cargo.toml
@@ -15,10 +15,10 @@ clap = { version = "4.4.0", features = ["derive","env"] }
 dotenvy = "0.15.0"
 env_logger = "0.10.0"
 libc = "0.2.154"
-log = "0.4.17"
+log = "0.4.21"
 reqwest = { version = "0.11.27", features = ["json", "native-tls-vendored"] }
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 # socksx = { git = "https://github.com/onnovalkering/socksx" }
 subprocess = "0.2.0"

--- a/brane-log/Cargo.toml
+++ b/brane-log/Cargo.toml
@@ -5,24 +5,24 @@ authors = { workspace = true }
 edition = "2018"
 
 [dependencies]
-anyhow = "1"
-async-stream = "0.3"
-bincode = "1.3"
-bytes = "1"
+anyhow = "1.0.0"
+async-stream = "0.3.0"
+bincode = "1.3.0"
+bytes = "1.0.0"
 clap = { version = "4.0.24", features = ["derive","env"] }
-derive_more = "0.99"
-dotenvy = "0.15"
-env_logger = "0.10"
-futures = "0.3"
-juniper = "0.15"
-juniper_graphql_ws = "0.3"
-juniper_warp = { version = "0.7", features = ["subscriptions"] }
-log = "0.4"
-prost = "0.11"
-rdkafka = { version = "0.31", features = ["cmake-build"] }
-scylla = "0.2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-time = { version = "0.3", features = ["formatting"] }
-tokio = { version = "1", features = ["full"] }
-warp = "0.3"
+derive_more = "0.99.0"
+dotenvy = "0.15.0"
+env_logger = "0.10.0"
+futures = "0.3.0"
+juniper = "0.15.0"
+juniper_graphql_ws = "0.3.0"
+juniper_warp = { version = "0.7.0", features = ["subscriptions"] }
+log = "0.4.0"
+prost = "0.11.0"
+rdkafka = { version = "0.31.0", features = ["cmake-build"] }
+scylla = "0.2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+time = { version = "0.3.0", features = ["formatting"] }
+tokio = { version = "1.0.0", features = ["full"] }
+warp = "0.3.0"

--- a/brane-oas/Cargo.toml
+++ b/brane-oas/Cargo.toml
@@ -10,13 +10,13 @@ backoff = { version = "0.3.0", features = ["tokio"] }
 brane-exe = { path = "../brane-exe" }
 cookie = "0.15.0"
 cookie_store = "0.15.0"
-log = "0.4.17"
+log = "0.4.21"
 maplit = "1.0"
 openapiv3 = "0.5.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.27", features = ["json", "cookies", "blocking"] }
 reqwest_cookie_store = "0.2.0"
-serde = "1.0.195"
-serde_json = "1.0.87"
+serde = "1.0.203"
+serde_json = "1.0.117"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 specifications = { path = "../specifications" }

--- a/brane-oas/Cargo.toml
+++ b/brane-oas/Cargo.toml
@@ -5,18 +5,18 @@ authors = { workspace = true }
 edition = "2018"
 
 [dependencies]
-anyhow = "1"
-backoff = { version = "0.3", features = ["tokio"] }
+anyhow = "1.0.66"
+backoff = { version = "0.3.0", features = ["tokio"] }
 brane-exe = { path = "../brane-exe" }
-cookie = "0.15"
-cookie_store = "0.15"
-log = "0.4"
-maplit = "1"
-openapiv3 = "0.5"
-rand = "0.8"
-reqwest = { version = "0.11", features = ["json", "cookies", "blocking"] }
-reqwest_cookie_store = "0.2"
-serde = "1"
-serde_json = "1"
+cookie = "0.15.0"
+cookie_store = "0.15.0"
+log = "0.4.17"
+maplit = "1.0"
+openapiv3 = "0.5.0"
+rand = "0.8.5"
+reqwest = { version = "0.11.27", features = ["json", "cookies", "blocking"] }
+reqwest_cookie_store = "0.2.0"
+serde = "1.0.195"
+serde_json = "1.0.87"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 specifications = { path = "../specifications" }

--- a/brane-plr/Cargo.toml
+++ b/brane-plr/Cargo.toml
@@ -6,20 +6,20 @@ edition = "2021"
 
 [dependencies]
 async-recursion = "1.0.0"
-clap = { version = "4.0.24", features = ["derive","env"] }
-dotenvy = "0.15"
+clap = { version = "4.4.0", features = ["derive","env"] }
+dotenvy = "0.15.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-futures-util = "0.3"
-log = "0.4"
-parking_lot = "0.12"
+futures-util = "0.3.30"
+log = "0.4.17"
+parking_lot = "0.12.1"
 rand = "0.8.5"
-reqwest = "0.11"
-serde_json = "1"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "signal"] }
-tokio-stream = "0.1"
-tonic = "0.11"
-warp = "0.3"
+reqwest = "0.11.27"
+serde_json = "1.0.87"
+tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
+tokio-stream = "0.1.6"
+tonic = "0.11.0"
+warp = "0.3.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-plr/Cargo.toml
+++ b/brane-plr/Cargo.toml
@@ -11,11 +11,11 @@ dotenvy = "0.15.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 futures-util = "0.3.30"
-log = "0.4.17"
+log = "0.4.21"
 parking_lot = "0.12.1"
 rand = "0.8.5"
 reqwest = "0.11.27"
-serde_json = "1.0.87"
+serde_json = "1.0.117"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-stream = "0.1.6"
 tonic = "0.11.0"

--- a/brane-prx/Cargo.toml
+++ b/brane-prx/Cargo.toml
@@ -6,22 +6,22 @@ authors = [ "Lut99" ]
 
 [dependencies]
 anyhow = "1.0.66"
-clap = { version = "4.0.24", features = ["derive","env"] }
+clap = { version = "4.4.0", features = ["derive","env"] }
 dotenvy = "0.15"
-env_logger = "0.10"
+env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-log = "0.4"
+log = "0.4.17"
 never-say-never = "6.6.666"
-reqwest = { version = "0.11", features = ["json"] }
-rustls = "0.21"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+reqwest = { version = "0.11.27", features = ["json"] }
+rustls = "0.21.6"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.87"
 socksx = { git = "https://github.com/epi-project/socksx" }
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "signal"] }
-tokio-rustls = "0.24"
-tonic = "0.11"
-url = "2.2"
-warp = "0.3"
+tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
+tokio-rustls = "0.24.0"
+tonic = "0.11.0"
+url = "2.5.0"
+warp = "0.3.0"
 
 brane-cfg = { path = "../brane-cfg" }
 brane-shr = { path = "../brane-shr" }

--- a/brane-prx/Cargo.toml
+++ b/brane-prx/Cargo.toml
@@ -10,12 +10,12 @@ clap = { version = "4.4.0", features = ["derive","env"] }
 dotenvy = "0.15"
 env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-log = "0.4.17"
+log = "0.4.21"
 never-say-never = "6.6.666"
 reqwest = { version = "0.11.27", features = ["json"] }
 rustls = "0.21.6"
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
 socksx = { git = "https://github.com/epi-project/socksx" }
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-rustls = "0.24.0"

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -5,25 +5,25 @@ edition = "2021"
 authors = [ "Tim Müller" ]
 
 [dependencies]
-base64 = "0.21"
-clap = { version = "4.0.24", features = ["derive","env"] }
+base64 = "0.21.0"
+clap = { version = "4.4.0", features = ["derive","env"] }
 deliberation = { git = "https://github.com/epi-project/policy-reasoner" }
-dotenvy = "0.15"
+dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug" }
-env_logger = "0.10"
+env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_23"] }
-log = "0.4"
-reqwest = "0.11"
-rustls = "0.21"
-serde = { version = "1", features = ["rc"] }
-serde_json = "1"
+log = "0.4.17"
+reqwest = "0.11.27"
+rustls = "0.21.6"
+serde = { version = "1.0.195", features = ["rc"] }
+serde_json = "1.0.87"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-tempfile = "3.2"
-tokio = { version = "1", features = ["rt","rt-multi-thread","macros","io-util", "signal"] }
-tokio-rustls = "0.24"
-tokio-stream = "0.1"
-warp = "0.3"
+tempfile = "3.3.0"
+tokio = { version = "1.38.0", features = ["rt","rt-multi-thread","macros","io-util", "signal"] }
+tokio-rustls = "0.24.0"
+tokio-stream = "0.1.6"
+warp = "0.3.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -13,13 +13,13 @@ enum-debug = { git = "https://github.com/Lut99/enum-debug" }
 env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_23"] }
-log = "0.4.17"
+log = "0.4.21"
 reqwest = "0.11.27"
 rustls = "0.21.6"
-serde = { version = "1.0.195", features = ["rc"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["rc"] }
+serde_json = "1.0.117"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-tempfile = "3.3.0"
+tempfile = "3.10.1"
 tokio = { version = "1.38.0", features = ["rt","rt-multi-thread","macros","io-util", "signal"] }
 tokio-rustls = "0.24.0"
 tokio-stream = "0.1.6"

--- a/brane-shr/Cargo.toml
+++ b/brane-shr/Cargo.toml
@@ -14,7 +14,7 @@ futures-util = "0.3.30"
 hex = "0.4.3"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 indicatif = "0.17.0"
-log = "0.4.17"
+log = "0.4.21"
 num-derive = "0.3.0"
 num-traits = "0.2.18"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
@@ -30,4 +30,4 @@ specifications = { path = "../specifications" }
 
 [dev-dependencies]
 getrandom = "0.2.8"
-tempfile = "3.3.0"
+tempfile = "3.10.1"

--- a/brane-shr/Cargo.toml
+++ b/brane-shr/Cargo.toml
@@ -6,28 +6,28 @@ edition = "2021"
 
 [dependencies]
 async-compression = { version = "0.3.15", features = ["tokio","gzip"] }
-console = "0.15"
-dialoguer = { version = "0.10", features = ["completion", "history"] }
+console = "0.15.5"
+dialoguer = { version = "0.10.0", features = ["completion", "history"] }
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-fs2 = "0.4"
-futures-util = "0.3"
+fs2 = "0.4.0"
+futures-util = "0.3.30"
 hex = "0.4.3"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-indicatif = "0.17"
-log = "0.4"
-num-derive = "0.3"
-num-traits = "0.2"
+indicatif = "0.17.0"
+log = "0.4.17"
+num-derive = "0.3.0"
+num-traits = "0.2.18"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
-regex = "1.5"
-reqwest = { version = "0.11", features = ["stream"] }
+regex = "1.5.0"
+reqwest = { version = "0.11.27", features = ["stream"] }
 sha2 = "0.10.6"
-tokio = { version = "1.20", features = ["rt","macros"] }
-tokio-stream = "0.1"
+tokio = { version = "1.38.0", features = ["rt","macros"] }
+tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"
-url = "2.2"
+url = "2.5.0"
 
 specifications = { path = "../specifications" }
 
 [dev-dependencies]
 getrandom = "0.2.8"
-tempfile = "3.2"
+tempfile = "3.3.0"

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -21,14 +21,14 @@ hyper = "0.14.29"
 indicatif = "0.17.0"
 # k8s-openapi = { version = "0.18", default_features = false, features = ["v1_23"] }
 # kube = { version = "0.83", default_features = false, features = ["client", "runtime", "rustls-tls"] }
-log = "0.4.17"
+log = "0.4.21"
 num-traits = "0.2.18"
 parking_lot = "0.12.1"
 prost = "0.12.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.27", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
-serde = "1.0.195"
-serde_json = "1.0.87"
+serde = "1.0.203"
+serde_json = "1.0.117"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 sha2 = "0.10.6"
 tokio = "1.38.0"

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -6,36 +6,36 @@ authors = [ "Tim Müller" ]
 
 
 [dependencies]
-async-trait = "0.1"
-base64 = "0.21"
-base64ct = { version = "1.5.3", features = ["alloc"] }
-bollard = "0.14"
-chrono = "0.4"
-console = "0.15"
-dialoguer = "0.11"
+async-trait = "0.1.67"
+base64 = "0.21.0"
+base64ct = { version = "1.6.0", features = ["alloc"] }
+bollard = "0.14.0"
+chrono = "0.4.23"
+console = "0.15.5"
+dialoguer = "0.11.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-futures-util = "0.3"
-graphql_client = "0.13"
-hex-literal = "0.4"
-hyper = "0.14"
-indicatif = "0.17"
+futures-util = "0.3.30"
+graphql_client = "0.13.0"
+hex-literal = "0.4.0"
+hyper = "0.14.29"
+indicatif = "0.17.0"
 # k8s-openapi = { version = "0.18", default_features = false, features = ["v1_23"] }
 # kube = { version = "0.83", default_features = false, features = ["client", "runtime", "rustls-tls"] }
-log = "0.4"
-num-traits = "0.2"
-parking_lot = "0.12"
-prost = "0.12"
-rand = "0.8"
-reqwest = { version = "0.11", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
-serde = "1"
-serde_json = "1"
+log = "0.4.17"
+num-traits = "0.2.18"
+parking_lot = "0.12.1"
+prost = "0.12.0"
+rand = "0.8.5"
+reqwest = { version = "0.11.27", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
+serde = "1.0.195"
+serde_json = "1.0.87"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 sha2 = "0.10.6"
-tokio = "1"
+tokio = "1.38.0"
 tokio-tar = "0.3.0"
-tokio-util = "0.7"
-tonic = "0.11"
-uuid = { version = "1.7", features = ["v4"] }
+tokio-util = "0.7.1"
+tonic = "0.11.0"
+uuid = { version = "1.7.0", features = ["v4"] }
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }
@@ -45,11 +45,11 @@ specifications = { path = "../specifications" }
 
 
 [dev-dependencies]
-clap = { version = "4.2", features = ["derive"] }
-dirs-2 = "3.0"
+clap = { version = "4.4.0", features = ["derive"] }
+dirs-2 = "3.0.0"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-lazy_static = "1.4"
-shellexpand = "3.1"
+lazy_static = "1.4.0"
+shellexpand = "3.1.0"
 
 
 # [build-dependencies]

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -15,15 +15,15 @@ enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"
 futures = "0.3.24"
 # lazy_static = "1.4.0"
 jsonwebtoken = "9.2.0"
-log = "0.4.17"
+log = "0.4.21"
 num-traits = "0.2.18"
 parking_lot = { version = "0.12.1", features = ["serde"] }
 prost = "0.12.0"
 prost-types = "0.12.0"
 reqwest = { version = "0.11.27", features = ["json", "stream"] }
 semver = "1.0.0"
-serde = { version = "1.0.195", features = ["derive", "rc"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.203", features = ["derive", "rc"] }
+serde_json = "1.0.117"
 serde_repr = "0.1.6"
 serde_test = "1.0.0"
 serde_with = "3.0.0"

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -5,30 +5,30 @@ authors = { workspace = true }
 edition = "2018"
 
 [dependencies]
-anyhow = "1"
-async-trait = "0.1.60"
-base64 = "0.21"
-base64ct = { version = "1.6", features = ["std"] }
+anyhow = "1.0.66"
+async-trait = "0.1.67"
+base64 = "0.21.0"
+base64ct = { version = "1.6.0", features = ["std"] }
 chrono = { version = "0.4.23", features = ["serde"] }
 const_format = "0.2.22"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-futures = "0.3"
+futures = "0.3.24"
 # lazy_static = "1.4.0"
-jsonwebtoken = "9.2"
+jsonwebtoken = "9.2.0"
 log = "0.4.17"
-num-traits = "0.2.15"
+num-traits = "0.2.18"
 parking_lot = { version = "0.12.1", features = ["serde"] }
-prost = "0.12"
-prost-types = "0.12"
-reqwest = { version = "0.11", features = ["json", "stream"] }
-semver = "1.0"
-serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
-serde_repr = "0.1"
-serde_test = "1.0"
-serde_with = "3.0"
+prost = "0.12.0"
+prost-types = "0.12.0"
+reqwest = { version = "0.11.27", features = ["json", "stream"] }
+semver = "1.0.0"
+serde = { version = "1.0.195", features = ["derive", "rc"] }
+serde_json = "1.0.87"
+serde_repr = "0.1.6"
+serde_test = "1.0.0"
+serde_with = "3.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-strum = "0.24"
-strum_macros = "0.24"
-tonic = "0.11"
-uuid = { version = "1.7", features = ["serde", "v4"] }
+strum = "0.24.0"
+strum_macros = "0.24.0"
+tonic = "0.11.0"
+uuid = { version = "1.7.0", features = ["serde", "v4"] }


### PR DESCRIPTION
Minimal versions were almost universally set incorrectly. This was a huge endeavour to fix, however I tried to be diligent about it. It will be the case that some are set too high now, but too high is a lot better than the previous too low.

This only takes take of direct minimal versions. Preferably we would also ensure that the transient dependencies have the correct minimal versions, but this will suffice (for now).

I can only fully test this when #90 has been merged, as some builds fail on the base of this branch. 