### PR TITLE
fix(ctl): Add CACHEDIR.TAG to target dir on create

### DIFF
--- a/brane-ctl/src/download.rs
+++ b/brane-ctl/src/download.rs
@@ -200,6 +200,12 @@ pub async fn services(
                 // user should be warned.
                 warn!("Could not tag directory: `./target` as cachedir, this could have implications for backup solutions and equivalent.\n{err:#}");
             }
+        } else {
+            if let Err(err) = cachedir::add_tag(&path) {
+                // Recovable, this does not need to impact the run of the application, but the
+                // user should be warned.
+                warn!("Could not tag directory: `{path:?}` as cachedir, this could have implications for backup solutions and equivalent.\n{err:#}");
+            }
         }
     }
     if !path.is_dir() {

--- a/brane-ctl/src/download.rs
+++ b/brane-ctl/src/download.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    20 Feb 2023, 14:59:16
 //  Last edited:
-//    13 Apr 2023, 09:56:02
+//    26 Jun 2024, 13:57:46
 //  Auto updated?
 //    Yes
 //
@@ -188,24 +188,6 @@ pub async fn services(
         }
         if let Err(err) = fs::create_dir_all(path) {
             return Err(Error::DirCreateError { what: "output", path: path.into(), err });
-        }
-
-        // Cargo places a CACHEDIR.TAG in the target directory upon creation, if we create the
-        // target directory instead, the directory is not and will not be tagged as a cache
-        // directory. This can cause issues with tools like backup solutions, which will start to
-        // back up the build artifacts.
-        if path.starts_with(Path::new("./target")) {
-            if let Err(err) = cachedir::add_tag(Path::new("./target")) {
-                // Recovable, this does not need to impact the run of the application, but the
-                // user should be warned.
-                warn!("Could not tag directory: `./target` as cachedir, this could have implications for backup solutions and equivalent.\n{err:#}");
-            }
-        } else {
-            if let Err(err) = cachedir::add_tag(&path) {
-                // Recovable, this does not need to impact the run of the application, but the
-                // user should be warned.
-                warn!("Could not tag directory: `{path:?}` as cachedir, this could have implications for backup solutions and equivalent.\n{err:#}");
-            }
         }
     }
     if !path.is_dir() {

--- a/brane-ctl/src/download.rs
+++ b/brane-ctl/src/download.rs
@@ -224,7 +224,7 @@ pub async fn services(
                                 Err(err) => return Err(Error::CachedirTagCreate { path: tag_path, err }),
                             };
                             if let Err(err) = handle.write(
-                                b"Signature: 8a477f597d28d172789f06886806bc55\n# This file is a cache directory tag created by BRANE's `branectl`.\n# For information about cache directory tags, see:\n#	    http://www.brynosaurus.com/cachedir/\n",
+                                b"Signature: 8a477f597d28d172789f06886806bc55\n# This file is a cache directory tag created by BRANE's `branectl`.\n# For information about cache directory tags, see:\n#	    https://www.brynosaurus.com/cachedir/\n",
                             ) {
                                 return Err(Error::CachedirTagWrite { path: tag_path, err })
                             }

--- a/make.py
+++ b/make.py
@@ -3865,7 +3865,7 @@ if __name__ == "__main__":
                         h.write(f"Signature: 8a477f597d28d172789f06886806bc55\n")
                         h.write(f"# This file is a cache directory tag created by BRANE's `make.py`.\n")
                         h.write(f"# For information about cache directory tags, see:\n")
-                        h.write(f"#	    http://www.brynosaurus.com/cachedir/\n")
+                        h.write(f"#	    https://www.brynosaurus.com/cachedir/\n")
                 except IOError as e:
                     pwarning(f"Failed to generate CACHEDIR.TAG at '{tag_path}': {e}")
                     exit(e.errno)

--- a/make.py
+++ b/make.py
@@ -5,7 +5,7 @@
 # Created:
 #   09 Jun 2022, 12:20:28
 # Last edited:
-#   30 Apr 2024, 10:46:16
+#   26 Jun 2024, 13:54:18
 # Auto updated?
 #   Yes
 #
@@ -3840,6 +3840,23 @@ if __name__ == "__main__":
 
     # Before we begin, move the current working directory to that of the file itself
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+    # Then make sure we generate the cache directory with a CACHEDIR.tag
+    if not os.path.exists(args.cache):
+        # Create the directory
+        os.makedirs(args.cache)
+
+        # Create the file
+        tag_path = os.path.join(args.cache, "CACHEDIR.TAG")
+        try:
+            with open(tag_path, "w") as h:
+                h.write(f"Signature: 8a477f597d28d172789f06886806bc55\n")
+                h.write(f"# This file is a cache directory tag created by BRANE's `make.py`.\n")
+                h.write(f"# For information about cache directory tags, see:\n")
+                h.write(f"#	    http://www.brynosaurus.com/cachedir/\n")
+        except IOError as e:
+            pwarning(f"Failed to generate CACHEDIR.TAG at '{tag_path}': {e}")
+            exit(e.errno)
 
     # Call for the given targets
     for target in args.target:


### PR DESCRIPTION
My backups have quadrupled in size, because if you download an image using `branectl` before you ever compile anything in brane, cargo will never annotate its target directory with a `CACHEDIR.TAG` (and rightfully so). However, this does mean that most backup solutions will gladly backup all your nice debug builds. :smiling_face_with_tear:.

Lets fix that, we do add a cachetag to the download directory itself if the target directory is not the one usually used by cargo.
