### PR TITLE
chore(deps): Remove seamingly unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,6 @@ dependencies = [
  "brane-shr 3.0.0",
  "console",
  "enum-debug",
- "im",
  "lazy_static",
  "log",
  "num-traits",
@@ -631,7 +630,6 @@ name = "brane-cfg"
 version = "3.0.0"
 dependencies = [
  "async-trait",
- "brane-shr 3.0.0",
  "enum-debug",
  "log",
  "rustls 0.21.12",
@@ -654,7 +652,6 @@ dependencies = [
  "bollard",
  "brane-ast 3.0.0",
  "brane-cfg",
- "brane-drv",
  "brane-dsl 3.0.0",
  "brane-exe 3.0.0",
  "brane-oas",
@@ -663,12 +660,10 @@ dependencies = [
  "chrono",
  "clap 4.5.7",
  "console",
- "cwl",
  "dialoguer 0.10.4",
  "dirs-2",
  "dotenvy",
  "enum-debug",
- "env_logger",
  "error-trace",
  "filetime",
  "flate2",
@@ -784,7 +779,7 @@ dependencies = [
  "brane-shr 3.0.0",
  "brane-tsk",
  "clap 4.5.7",
- "dashmap 5.5.3",
+ "dashmap",
  "dotenvy",
  "enum-debug",
  "env_logger",
@@ -808,7 +803,6 @@ dependencies = [
  "brane-shr 3.0.0",
  "bytes",
  "enum-debug",
- "itertools 0.10.5",
  "log",
  "nom",
  "nom_locate",
@@ -859,7 +853,6 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "simplelog",
  "specifications 3.0.0",
  "tokio",
  "uuid 1.9.1",
@@ -902,7 +895,6 @@ dependencies = [
  "brane-tsk",
  "chrono",
  "clap 4.5.7",
- "dashmap 4.0.2",
  "deliberation",
  "dotenvy",
  "enum-debug",
@@ -941,7 +933,6 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "specifications 3.0.0",
- "subprocess",
  "tokio",
  "tonic",
  "yaml-rust2",
@@ -1042,7 +1033,6 @@ dependencies = [
  "enum-debug",
  "env_logger",
  "error-trace",
- "k8s-openapi",
  "log",
  "reqwest 0.11.27",
  "rustls 0.21.12",
@@ -1072,7 +1062,6 @@ dependencies = [
  "humanlog",
  "indicatif",
  "log",
- "num-derive 0.3.3",
  "num-traits",
  "regex",
  "reqwest 0.11.27",
@@ -1125,14 +1114,11 @@ dependencies = [
  "brane-exe 3.0.0",
  "brane-shr 3.0.0",
  "chrono",
- "clap 4.5.7",
  "console",
  "dialoguer 0.11.0",
- "dirs-2",
  "enum-debug",
  "futures-util",
  "graphql_client",
- "hex-literal",
  "humanlog",
  "hyper 0.14.29",
  "indicatif",
@@ -1147,7 +1133,6 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "sha2",
- "shellexpand",
  "specifications 3.0.0",
  "tokio",
  "tokio-tar",
@@ -1492,49 +1477,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cwl"
-version = "0.1.0"
-source = "git+https://github.com/onnovalkering/cwl-rs#4db80bd5fb435885437c42db6a97bc2143400325"
-dependencies = [
- "anyhow",
- "log",
- "serde",
- "serde_with 1.14.0",
- "serde_yaml",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core 0.20.9",
- "darling_macro 0.20.9",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1553,34 +1502,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core 0.20.9",
+ "darling_core",
  "quote",
  "syn 2.0.68",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if",
- "num_cpus",
 ]
 
 [[package]]
@@ -1744,15 +1672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-2"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,18 +1690,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.4.5",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1844,7 +1751,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0892a17df262a24294c382f0d5997571006e7a4348b4327557c4ff1cd4a8bccc"
 dependencies = [
- "darling 0.20.9",
+ "darling",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -1978,7 +1885,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14e0b79235da57db6b6c2beed9af6e5de867d63a973ae3e91910ddc33ba40bc0"
 dependencies = [
- "dirs 1.0.5",
+ "dirs",
  "lazy_static",
  "pwd",
 ]
@@ -2956,20 +2863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "k8s-openapi"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "chrono",
- "serde",
- "serde-value",
- "serde_json",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,21 +3343,6 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -4335,7 +4213,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "histogram",
  "itertools 0.11.0",
@@ -4380,7 +4258,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb6085ff9c3fd7e5163826901d39164ab86f11bdca16b2f766a00c528ff9cef9"
 dependencies = [
- "darling 0.20.9",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -4437,16 +4315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]
@@ -4525,16 +4393,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
@@ -4562,20 +4420,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.8.1",
+ "serde_with_macros",
  "time 0.3.36",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4584,7 +4430,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
- "darling 0.20.9",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -4663,15 +4509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
-name = "shellexpand"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
-dependencies = [
- "dirs 5.0.1",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4709,17 +4546,6 @@ dependencies = [
  "log",
  "time 0.3.36",
  "winapi",
-]
-
-[[package]]
-name = "simplelog"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
-dependencies = [
- "log",
- "termcolor",
- "time 0.3.36",
 ]
 
 [[package]]
@@ -4816,12 +4642,10 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "prost",
- "prost-types",
  "reqwest 0.11.27",
  "semver 1.0.23",
  "serde",
  "serde_json",
- "serde_repr",
  "serde_test",
  "serde_with 3.8.1",
  "serde_yml",
@@ -4985,12 +4809,6 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5053,16 +4871,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.68",
-]
-
-[[package]]
-name = "subprocess"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/brane-ast/Cargo.toml
+++ b/brane-ast/Cargo.toml
@@ -8,7 +8,6 @@ rust-version = "1.67.1"
 [dependencies]
 console = "0.15.5"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-im = "15.1.0"
 lazy_static = "1.4.0"
 log = "0.4.21"
 rand = "0.8.5"

--- a/brane-cfg/Cargo.toml
+++ b/brane-cfg/Cargo.toml
@@ -16,5 +16,4 @@ serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tokio = { version = "1.38.0", features = [] }
 x509-parser = "0.15.0"
 
-brane-shr      = { path = "../brane-shr" }
 specifications = { path = "../specifications" }

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -18,12 +18,10 @@ bollard = "0.14.0"
 chrono = "0.4.23"
 clap = { version = "4.4.0", features = ["derive","env"] }
 console = "0.15.5"
-cwl = { git = "https://github.com/onnovalkering/cwl-rs" }
 dialoguer = "0.10.0"
 dirs-2 = "3.0.1"
 dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 filetime = "0.2.15"
 flate2 = { version = "1.0.13", features = ["zlib"], default-features = false }
@@ -66,7 +64,6 @@ x509-parser = "0.15.0"
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }
-brane-drv = { path = "../brane-drv" }
 brane-dsl = { path = "../brane-dsl" }
 brane-exe = { path = "../brane-exe" }
 brane-oas = { path = "../brane-oas" }

--- a/brane-dsl/Cargo.toml
+++ b/brane-dsl/Cargo.toml
@@ -8,7 +8,6 @@ rust-version = "1.67.1"
 [dependencies]
 bytes = "1.2.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-itertools = "0.10.0"
 log = "0.4.21"
 nom = "7.1.0"
 nom_locate = "4.1.0"

--- a/brane-exe/Cargo.toml
+++ b/brane-exe/Cargo.toml
@@ -26,8 +26,6 @@ brane-shr = { path = "../brane-shr" }
 specifications = { path = "../specifications" }
 
 [dev-dependencies]
-simplelog = "0.12.0"
-
 brane-shr = { path = "../brane-shr" }
 
 [features]

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -36,6 +36,3 @@ brane-prx = { path = "../brane-prx" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
 specifications = { path = "../specifications" }
-
-[dev-dependencies]
-dashmap = "4.0.0"

--- a/brane-let/Cargo.toml
+++ b/brane-let/Cargo.toml
@@ -21,8 +21,6 @@ reqwest = { version = "0.11.27", features = ["json", "native-tls-vendored"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
-# socksx = { git = "https://github.com/onnovalkering/socksx" }
-subprocess = "0.2.0"
 tokio = { version = "1.38.0", features = ["full", "time"] }
 tonic = "0.11.0"
 yaml-rust = { version = "0.8", package = "yaml-rust2" }

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -13,7 +13,6 @@ dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug" }
 env_logger = "0.10.0"
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_23"] }
 log = "0.4.21"
 reqwest = "0.11.27"
 rustls = "0.21.6"

--- a/brane-shr/Cargo.toml
+++ b/brane-shr/Cargo.toml
@@ -16,9 +16,7 @@ hex = "0.4.3"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 indicatif = "0.17.0"
 log = "0.4.21"
-num-derive = "0.3.0"
 num-traits = "0.2.18"
-# rdkafka = { version = "0.31", features = ["cmake-build"] }
 regex = "1.5.0"
 reqwest = { version = "0.11.27", features = ["stream"] }
 sha2 = "0.10.6"

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -17,11 +17,8 @@ dialoguer = "0.11.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 futures-util = "0.3.30"
 graphql_client = "0.13.0"
-hex-literal = "0.4.0"
 hyper = "0.14.29"
 indicatif = "0.17.0"
-# k8s-openapi = { version = "0.18", default_features = false, features = ["v1_23"] }
-# kube = { version = "0.83", default_features = false, features = ["client", "runtime", "rustls-tls"] }
 log = "0.4.21"
 num-traits = "0.2.18"
 parking_lot = "0.12.1"
@@ -46,11 +43,8 @@ specifications = { path = "../specifications" }
 
 
 [dev-dependencies]
-clap = { version = "4.4.0", features = ["derive"] }
-dirs-2 = "3.0.0"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 lazy_static = "1.4.0"
-shellexpand = "3.1.0"
 
 
 # [build-dependencies]

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -20,12 +20,10 @@ log = "0.4.21"
 num-traits = "0.2.18"
 parking_lot = { version = "0.12.1", features = ["serde"] }
 prost = "0.12.0"
-prost-types = "0.12.0"
 reqwest = { version = "0.11.27", features = ["json", "stream"] }
 semver = "1.0.0"
 serde = { version = "1.0.203", features = ["derive", "rc"] }
 serde_json = "1.0.117"
-serde_repr = "0.1.6"
 serde_test = "1.0.0"
 serde_with = "3.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }


### PR DESCRIPTION
This has been checked by compilation with cargo-udeps as source

@lut99 Could you scan this through for something I could have missed here?
