### PR TITLE
chore(overview): Add Rust edition to overview

### DIFF
--- a/overview/Cargo.toml
+++ b/overview/Cargo.toml
@@ -4,3 +4,4 @@ version = { workspace = true }
 authors = { workspace = true }
 description = "Dummy crate for having a nice entrypoint in the generated docs."
 rust-version = "1.64.0"
+edition = "2021"


### PR DESCRIPTION
This gives a warning without an edition