### PR TITLE
feat(docker): Add host.docker.internal

### DIFF
--- a/docker-compose-central.yml
+++ b/docker-compose-central.yml
@@ -32,6 +32,8 @@ services:
     - ${NODE_CONFIG_PATH}:/node.yml
     - ${PROXY:-}:${PROXY:-}
     - ${CERTS}:${CERTS}
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
   # The service in charge of package registry, downloading, uploading, etc
   brane-api:
@@ -53,6 +55,8 @@ services:
     labels:
     - kompose.service.type=nodeport
     - kompose.service.nodeport.port=50051
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
   # The service that accepts client connections and executes workflow control flow
   brane-drv:
@@ -71,6 +75,8 @@ services:
     labels:
     - kompose.service.type=nodeport
     - kompose.service.nodeport.port=50053
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
   # # The service logging everything
   # brane-log:
@@ -97,6 +103,8 @@ services:
     volumes:
     - ${NODE_CONFIG_PATH}:/node.yml
     - ${INFRA}:${INFRA}
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
 networks:
   default:

--- a/docker-compose-proxy.yml
+++ b/docker-compose-proxy.yml
@@ -22,6 +22,8 @@ services:
     - ${NODE_CONFIG_PATH}:/node.yml
     - ${PROXY}:${PROXY}
     - ${CERTS}:${CERTS}
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
 networks:
   default:

--- a/docker-compose-worker.yml
+++ b/docker-compose-worker.yml
@@ -23,6 +23,8 @@ services:
     - ${NODE_CONFIG_PATH}:/node.yml
     - ${PROXY:-}:${PROXY:-}
     - ${CERTS}:${CERTS}
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
   # The service in charge of policy
   brane-chk:
@@ -40,6 +42,8 @@ services:
     - ${POLICY_DB}:/data/policy.db
     - ${POLICY_DELIBERATION_SECRET}:/examples/config/jwk_set_delib.json
     - ${POLICY_EXPERT_SECRET}:/examples/config/jwk_set_expert.json
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
   # The service in charge of the local container- and data registry
   brane-reg:
@@ -56,6 +60,8 @@ services:
     - ${POLICY_DELIBERATION_SECRET}:${POLICY_DELIBERATION_SECRET}
     - ${DATA}:${DATA}
     - ${RESULTS}:${RESULTS}
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
   # The service that is the 'main' service on the worker.
   brane-job:
@@ -76,6 +82,8 @@ services:
     - ${TEMP_DATA}:${TEMP_DATA}
     - ${TEMP_RESULTS}:${TEMP_RESULTS}
     - /var/run/docker.sock:/var/run/docker.sock
+    extra_hosts:
+    - host.docker.internal:host-gateway
 
 networks:
   default:


### PR DESCRIPTION
Add alias for host.docker.internal
This change makes setting up Brane on single machines a lot easier

Note that we cannot use host-gateway instead. This is a special string that can be used in extra hosts, that will be _substituted_ by the docker host IP address, it is not a DNS entry itself.