### PR TITLE
Fix checker image not compiling

### DIFF
--- a/Dockerfile.rls
+++ b/Dockerfile.rls
@@ -72,8 +72,8 @@ RUN mkdir -p /policy-reasoner/data && touch /policy-reasoner/data/policy.db
 WORKDIR /policy-reasoner
 RUN --mount=type=cache,id=cargoidx,target=/usr/local/cargo/registry \
     --mount=type=cache,id=reasonercache,target=/policy-reasoner/target \
-    cargo build --release --features brane-api-resolver \
- && cp ./target/release/policy-reasoner /brane-chk
+    cargo build --release --bin eflint --features brane-api-resolver \
+ && cp ./target/release/eflint /brane-chk
 
 # If ever run, run a shell
 WORKDIR /

--- a/Dockerfile.rls
+++ b/Dockerfile.rls
@@ -61,6 +61,7 @@ LABEL org.opencontainers.image.source https://github.com/epi-project/brane
 
 # Fetch the reasoner code next
 WORKDIR /
+ARG REASONER=eflint
 ARG REASONER_BRANCH=main
 ADD "http://github.com/epi-project/policy-reasoner/zipball/${REASONER_BRANCH}/" /policy-reasoner.zip
 RUN unzip /policy-reasoner.zip && mv /epi-project-policy-reasoner* /policy-reasoner
@@ -72,8 +73,8 @@ RUN mkdir -p /policy-reasoner/data && touch /policy-reasoner/data/policy.db
 WORKDIR /policy-reasoner
 RUN --mount=type=cache,id=cargoidx,target=/usr/local/cargo/registry \
     --mount=type=cache,id=reasonercache,target=/policy-reasoner/target \
-    cargo build --release --bin eflint --features brane-api-resolver \
- && cp ./target/release/eflint /brane-chk
+    cargo build --release --bin $REASONER --features brane-api-resolver \
+ && cp ./target/release/$REASONER /brane-chk
 
 # If ever run, run a shell
 WORKDIR /


### PR DESCRIPTION
Fixed #117

A recent change over at the policy reasoner has introduced multiple binaries for multiple reasoning backends. The Dockerfile for the checker image hasn't been updated, so it attempted to copy the no-longer existing `policy-reasoner`.

In addition, also added a `make.py` flag for changing the reasoner binary that is being built.