### PR TITLE
feat(branectl): Add logs subcommand

### DIFF
--- a/brane-ctl/src/cli.rs
+++ b/brane-ctl/src/cli.rs
@@ -129,6 +129,15 @@ pub(crate) enum CtlSubcommand {
         #[clap(short, long, help = concat!("The docker-compose.yml file that defines the services to stop. You can use '$NODE' to match either 'central' or 'worker', depending how we started. If omitted, will use the baked-in counterpart (although that only works for the default version, v", env!("CARGO_PKG_VERSION"), ")."))]
         file: Option<PathBuf>,
     },
+    #[clap(name = "logs", about = "Show the logs for the specficied node")]
+    Logs {
+        /// The docker-compose command we run.
+        #[clap(short, long, default_value = "docker compose", help = "The command to use to run Docker Compose.")]
+        exe:  String,
+        /// The docker-compose file that we start.
+        #[clap(short, long, help = concat!("The docker-compose.yml file that defines the services to log. You can use '$NODE' to match either 'central' or 'worker', depending how we started. If omitted, will use the baked-in counterpart (although that only works for the default version, v", env!("CARGO_PKG_VERSION"), ")."))]
+        file: Option<PathBuf>,
+    },
 
     #[clap(name = "version", about = "Returns the version of this CTL tool and/or the local node.")]
     Version {

--- a/brane-ctl/src/lifetime.rs
+++ b/brane-ctl/src/lifetime.rs
@@ -677,7 +677,7 @@ fn construct_envs(version: &Version, node_config_path: &Path, node_config: &Node
 // TODO: Maybe wrap the (extra) arguments as value in the command
 enum DockerComposeCommand {
     Up,
-    Logs
+    Logs,
 }
 
 impl DockerComposeCommand {
@@ -845,7 +845,15 @@ pub async fn start(
             let envs: HashMap<&str, OsString> = construct_envs(&opts.version, &node_config_path, &node_config)?;
 
             // Launch the docker-compose command
-            run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Up, resolve_node(file, "central"), &node_config.namespace, overridefile, envs)?;
+            run_compose(
+                opts.compose_verbose,
+                resolve_exe(exe)?,
+                DockerComposeCommand::Up,
+                resolve_node(file, "central"),
+                &node_config.namespace,
+                overridefile,
+                envs,
+            )?;
         },
 
         StartSubcommand::Worker { brane_prx, brane_chk, brane_reg, brane_job } => {
@@ -885,7 +893,15 @@ pub async fn start(
             let envs: HashMap<&str, OsString> = construct_envs(&opts.version, &node_config_path, &node_config)?;
 
             // Launch the docker-compose command
-            run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Up, resolve_node(file, "worker"), &node_config.namespace, overridefile, envs)?;
+            run_compose(
+                opts.compose_verbose,
+                resolve_exe(exe)?,
+                DockerComposeCommand::Up,
+                resolve_node(file, "worker"),
+                &node_config.namespace,
+                overridefile,
+                envs,
+            )?;
         },
 
         StartSubcommand::Proxy { brane_prx } => {
@@ -915,7 +931,15 @@ pub async fn start(
             let envs: HashMap<&str, OsString> = construct_envs(&opts.version, &node_config_path, &node_config)?;
 
             // Launch the docker-compose command
-            run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Up, resolve_node(file, "proxy"), &node_config.namespace, overridefile, envs)?;
+            run_compose(
+                opts.compose_verbose,
+                resolve_exe(exe)?,
+                DockerComposeCommand::Up,
+                resolve_node(file, "proxy"),
+                &node_config.namespace,
+                overridefile,
+                envs,
+            )?;
         },
     }
 
@@ -1011,12 +1035,7 @@ pub fn stop(compose_verbose: bool, exe: impl AsRef<str>, file: Option<PathBuf>, 
     Ok(())
 }
 
-pub async fn logs(
-    exe: impl AsRef<str>,
-    file: Option<PathBuf>,
-    node_config_path: impl Into<PathBuf>,
-    opts: LogsOpts,
-) -> Result<(), Error> {
+pub async fn logs(exe: impl AsRef<str>, file: Option<PathBuf>, node_config_path: impl Into<PathBuf>, opts: LogsOpts) -> Result<(), Error> {
     let exe: &str = exe.as_ref();
     let node_config_path: PathBuf = node_config_path.into();
     info!(
@@ -1044,7 +1063,15 @@ pub async fn logs(
     let envs: HashMap<&str, OsString> = construct_envs(&version, &node_config_path, &node_config)?;
 
     // Launch the docker-compose command
-    run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Logs, resolve_node(file, "$NODE"), &node_config.namespace, None, envs)?;
+    run_compose(
+        opts.compose_verbose,
+        resolve_exe(exe)?,
+        DockerComposeCommand::Logs,
+        resolve_node(file, "$NODE"),
+        &node_config.namespace,
+        None,
+        envs,
+    )?;
 
     Ok(())
 }

--- a/brane-ctl/src/lifetime.rs
+++ b/brane-ctl/src/lifetime.rs
@@ -40,7 +40,7 @@ use specifications::container::Image;
 use specifications::version::Version;
 
 pub use crate::errors::LifetimeError as Error;
-use crate::spec::{StartOpts, StartSubcommand};
+use crate::spec::{LogsOpts, StartOpts, StartSubcommand};
 
 
 /***** HELPER STRUCTS *****/
@@ -674,6 +674,21 @@ fn construct_envs(version: &Version, node_config_path: &Path, node_config: &Node
     Ok(res)
 }
 
+// TODO: Maybe wrap the (extra) arguments as value in the command
+enum DockerComposeCommand {
+    Up,
+    Logs
+}
+
+impl DockerComposeCommand {
+    fn to_args(&self) -> Vec<&'static str> {
+        match self {
+            DockerComposeCommand::Up => vec!["up", "-d"],
+            DockerComposeCommand::Logs => vec!["logs", "-f"],
+        }
+    }
+}
+
 /// Runs Docker compose on the given Docker file.
 ///
 /// # Arguments
@@ -693,6 +708,7 @@ fn construct_envs(version: &Version, node_config_path: &Path, node_config: &Node
 fn run_compose(
     compose_verbose: bool,
     exe: (String, Vec<String>),
+    command: DockerComposeCommand,
     file: impl AsRef<Path>,
     project: impl AsRef<str>,
     overridefile: Option<PathBuf>,
@@ -713,7 +729,7 @@ fn run_compose(
         cmd.arg("-f");
         cmd.arg(overridefile);
     }
-    cmd.args(["up", "-d"]);
+    cmd.args(command.to_args());
     cmd.envs(envs);
     cmd.stdin(Stdio::inherit());
     cmd.stdout(Stdio::inherit());
@@ -829,7 +845,7 @@ pub async fn start(
             let envs: HashMap<&str, OsString> = construct_envs(&opts.version, &node_config_path, &node_config)?;
 
             // Launch the docker-compose command
-            run_compose(opts.compose_verbose, resolve_exe(exe)?, resolve_node(file, "central"), &node_config.namespace, overridefile, envs)?;
+            run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Up, resolve_node(file, "central"), &node_config.namespace, overridefile, envs)?;
         },
 
         StartSubcommand::Worker { brane_prx, brane_chk, brane_reg, brane_job } => {
@@ -869,7 +885,7 @@ pub async fn start(
             let envs: HashMap<&str, OsString> = construct_envs(&opts.version, &node_config_path, &node_config)?;
 
             // Launch the docker-compose command
-            run_compose(opts.compose_verbose, resolve_exe(exe)?, resolve_node(file, "worker"), &node_config.namespace, overridefile, envs)?;
+            run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Up, resolve_node(file, "worker"), &node_config.namespace, overridefile, envs)?;
         },
 
         StartSubcommand::Proxy { brane_prx } => {
@@ -899,7 +915,7 @@ pub async fn start(
             let envs: HashMap<&str, OsString> = construct_envs(&opts.version, &node_config_path, &node_config)?;
 
             // Launch the docker-compose command
-            run_compose(opts.compose_verbose, resolve_exe(exe)?, resolve_node(file, "proxy"), &node_config.namespace, overridefile, envs)?;
+            run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Up, resolve_node(file, "proxy"), &node_config.namespace, overridefile, envs)?;
         },
     }
 
@@ -992,5 +1008,43 @@ pub fn stop(compose_verbose: bool, exe: impl AsRef<str>, file: Option<PathBuf>, 
     }
 
     // Done
+    Ok(())
+}
+
+pub async fn logs(
+    exe: impl AsRef<str>,
+    file: Option<PathBuf>,
+    node_config_path: impl Into<PathBuf>,
+    opts: LogsOpts,
+) -> Result<(), Error> {
+    let exe: &str = exe.as_ref();
+    let node_config_path: PathBuf = node_config_path.into();
+    info!(
+        "Showing logs for node from Docker compose file '{}', defined in '{}'",
+        file.as_ref().map(|f| f.display().to_string()).unwrap_or_else(|| "<baked-in>".into()),
+        node_config_path.display()
+    );
+
+    // Start by loading the node config file
+    debug!("Loading node config file '{}'...", node_config_path.display());
+    let node_config: NodeConfig = match NodeConfig::from_path(&node_config_path) {
+        Ok(config) => config,
+        Err(err) => {
+            return Err(Error::NodeConfigLoadError { err });
+        },
+    };
+
+    let version = Version::from_str(env!("CARGO_PKG_VERSION")).unwrap();
+
+    // Resolve the Docker Compose file
+    debug!("Resolving Docker Compose file...");
+    let file: PathBuf = resolve_docker_compose_file(file, node_config.node.kind(), version)?;
+
+    // Construct the environment variables
+    let envs: HashMap<&str, OsString> = construct_envs(&version, &node_config_path, &node_config)?;
+
+    // Launch the docker-compose command
+    run_compose(opts.compose_verbose, resolve_exe(exe)?, DockerComposeCommand::Logs, resolve_node(file, "$NODE"), &node_config.namespace, None, envs)?;
+
     Ok(())
 }

--- a/brane-ctl/src/main.rs
+++ b/brane-ctl/src/main.rs
@@ -236,14 +236,7 @@ async fn main() {
             }
         },
         CtlSubcommand::Logs { exe, file } => {
-            if let Err(err) = lifetime::logs(
-                exe,
-                file,
-                args.node_config,
-                LogsOpts { compose_verbose: args.debug || args.trace },
-            )
-            .await
-            {
+            if let Err(err) = lifetime::logs(exe, file, args.node_config, LogsOpts { compose_verbose: args.debug || args.trace }).await {
                 error!("{}", err.trace());
                 std::process::exit(1);
             }

--- a/brane-ctl/src/main.rs
+++ b/brane-ctl/src/main.rs
@@ -14,7 +14,7 @@
 
 
 use brane_cfg::proxy::ForwardConfig;
-use brane_ctl::spec::StartOpts;
+use brane_ctl::spec::{LogsOpts, StartOpts};
 use brane_ctl::{download, generate, lifetime, packages, policies, unpack, upgrade, wizard};
 use brane_tsk::docker::DockerOptions;
 use dotenvy::dotenv;
@@ -231,6 +231,19 @@ async fn main() {
         },
         CtlSubcommand::Stop { exe, file } => {
             if let Err(err) = lifetime::stop(args.debug || args.trace, exe, file, args.node_config) {
+                error!("{}", err.trace());
+                std::process::exit(1);
+            }
+        },
+        CtlSubcommand::Logs { exe, file } => {
+            if let Err(err) = lifetime::logs(
+                exe,
+                file,
+                args.node_config,
+                LogsOpts { compose_verbose: args.debug || args.trace },
+            )
+            .await
+            {
                 error!("{}", err.trace());
                 std::process::exit(1);
             }

--- a/brane-ctl/src/spec.rs
+++ b/brane-ctl/src/spec.rs
@@ -293,6 +293,13 @@ pub struct StartOpts {
     pub profile_dir: Option<PathBuf>,
 }
 
+/// Defines a collection of options to pass to the `logs`-subcommand handler.
+#[derive(Clone, Debug)]
+pub struct LogsOpts {
+    /// Whether to enable extra verbosity for Docker Compose.
+    pub compose_verbose: bool,
+}
+
 
 
 /// A bit awkward here, but defines the subcommand for downloading service images from the repo.


### PR DESCRIPTION
With this subcommand you can see the collective logs of an entire node in a single output.

Fixes: #112 