### PR TITLE
style: Rename control node to central node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ This release basically sees the release of an entirely rebuilt framework. Expect
 - `make.sh` into `make.py`, which is completely re-designed to be more managable and complex (especially w.r.t. deciding if recompilation is necessary or not).
 - `brane push`, `brane pull` and `brane remove` to accept multiple packages to push, pull or remove respectively.
 - `specifications::version::Version` to be able to parse a given `<name>:<version>` pair (which will likely be the default way of entering versions from now on).
-- `docker-compose-*.yml` and `make.py` to make an explicit difference between a centralized, general control node and a domain-local worker node.
+- `docker-compose-*.yml` and `make.py` to make an explicit difference between a centralized, general central node and a domain-local worker node.
 - `brane-api` now needs to have knowledge about the infrastructure too (i.e., be provided with the `infra.yml` file).
 - `brane-job` to now explicitly live on a domain instead of the central node.
 - the semantics of the `install` section in `container.yml` files: now, the commands are processed _before_ the workspace is copied over instead of after in order to be much nicer to Docker caching. To emulate the old behaviour, use the new `unpack` section (see above).

--- a/brane-cfg/src/node.rs
+++ b/brane-cfg/src/node.rs
@@ -88,8 +88,8 @@ impl<'de> YamlInfo<'de> for NodeConfig {}
 #[derive(Clone, Debug, Deserialize, EnumDebug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NodeSpecificConfig {
-    /// Defines the services for the control node.
-    #[serde(alias = "control")]
+    /// Defines the services for the central node.
+    #[serde(alias = "central")]
     Central(CentralConfig),
     /// Defines the services for the worker node.
     Worker(WorkerConfig),
@@ -339,7 +339,7 @@ impl NodeSpecificConfig {
 
 
 
-/// Defines the configuration for the central/control node.
+/// Defines the configuration for the central node.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CentralConfig {
     /// Defines the paths for this node.
@@ -348,7 +348,7 @@ pub struct CentralConfig {
     pub services: CentralServices,
 }
 
-/// Defines the paths for the central/control node.
+/// Defines the paths for the central node.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CentralPaths {
     /// The path to the certificate directory.
@@ -362,7 +362,7 @@ pub struct CentralPaths {
     pub proxy: Option<PathBuf>,
 }
 
-/// Defines the services for the central/control node.
+/// Defines the services for the central node.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CentralServices {
     // Brane services

--- a/brane-cfg/src/node.rs
+++ b/brane-cfg/src/node.rs
@@ -89,7 +89,7 @@ impl<'de> YamlInfo<'de> for NodeConfig {}
 #[serde(rename_all = "snake_case")]
 pub enum NodeSpecificConfig {
     /// Defines the services for the central node.
-    #[serde(alias = "central")]
+    #[serde(alias = "control")]
     Central(CentralConfig),
     /// Defines the services for the worker node.
     Worker(WorkerConfig),

--- a/brane-job/src/worker.rs
+++ b/brane-job/src/worker.rs
@@ -229,18 +229,18 @@ struct PolicyValidateRequest {
 /***** AUXILLARY STRUCTURES *****/
 /// Helper structure for grouping together task-dependent "constants", but that are not part of the task itself.
 #[derive(Clone, Debug)]
-pub struct ControlNodeInfo {
+pub struct CentralNodeInfo {
     /// The address of the API service.
     pub api_endpoint: String,
 }
-impl ControlNodeInfo {
-    /// Constructor for the ControlNodeInfo.
+impl CentralNodeInfo {
+    /// Constructor for the CentralNodeInfo.
     ///
     /// # Arguments
     /// - `api_endpoint`: The address of the API service.
     ///
     /// # Returns
-    /// A new ControlNodeInfo instance.
+    /// A new CentralNodeInfo instance.
     #[inline]
     pub fn new(api_endpoint: impl Into<String>) -> Self { Self { api_endpoint: api_endpoint.into() } }
 }
@@ -1352,7 +1352,7 @@ async fn execute_task_local(
 /// - `tx`: The channel to transmit stuff back to the client on.
 /// - `use_case`: A string denoting which use-case (registry) we're using.
 /// - `workflow`: The Workflow that we're executing. Useful for communicating with the eFLINT backend.
-/// - `cinfo`: The ControlNodeInfo that specifies where to find services over at the control node.
+/// - `cinfo`: The CentralNodeInfo that specifies where to find services over at the central node.
 /// - `tinfo`: The TaskInfo that describes the task itself to execute.
 /// - `keep_container`: Whether to keep the container after execution or not.
 /// - `prof`: A ProfileScope to provide more detailled information about the time it takes to execute a task.
@@ -1369,7 +1369,7 @@ async fn execute_task(
     tx: Sender<Result<ExecuteReply, Status>>,
     use_case: &str,
     workflow: Workflow,
-    cinfo: ControlNodeInfo,
+    cinfo: CentralNodeInfo,
     tinfo: TaskInfo,
     keep_container: bool,
     prof: ProfileScopeHandle<'_>,
@@ -2081,8 +2081,8 @@ impl JobService for WorkerServer {
             },
         };
 
-        // Collect some request data into ControlNodeInfo's and TaskInfo's.
-        let cinfo: ControlNodeInfo = ControlNodeInfo::new(api.to_string());
+        // Collect some request data into CentralNodeInfo's and TaskInfo's.
+        let cinfo: CentralNodeInfo = CentralNodeInfo::new(api.to_string());
         let tinfo: TaskInfo = TaskInfo::new(
             task.function.name.clone(),
             ProgramCounter::new(

--- a/make.py
+++ b/make.py
@@ -31,9 +31,9 @@ import typing
 
 
 ##### CONSTANTS #####
-# List of services that live in the control part of an instance
+# List of services that live in the central part of an instance
 CENTRAL_SERVICES = [ "prx", "api", "drv", "plr" ]
-# List of auxillary services in the control part of an instance
+# List of auxillary services in the central part of an instance
 # At least, the ones we have to build.
 AUX_CENTRAL_SERVICES = []
 # List of services that live in a worker node in an instance


### PR DESCRIPTION
This is the yield of a simple grep, I might be missing some instances, but this should be most.

I left some old stuff regarding k8s as I was unclear whether it was refering to Brane or k8s control planes, but that stuff is unused right now anyway.
