### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,16 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "argon2rs"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
-dependencies = [
- "blake2-rfc",
- "scoped_threadpool",
-]
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,15 +140,6 @@ name = "arrayref"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
-
-[[package]]
-name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "arrayvec"
@@ -449,23 +430,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "blake2-rfc"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-dependencies = [
- "arrayvec 0.4.12",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -652,7 +623,7 @@ dependencies = [
  "clap_complete",
  "console",
  "dialoguer 0.11.0",
- "dirs-2",
+ "dirs 5.0.1",
  "dotenvy",
  "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
@@ -731,7 +702,7 @@ dependencies = [
  "dialoguer 0.11.0",
  "diesel",
  "diesel_migrations",
- "dirs-2",
+ "dirs 5.0.1",
  "dotenvy",
  "download",
  "eflint-to-json",
@@ -1108,7 +1079,6 @@ dependencies = [
  "clap 4.5.9",
  "console",
  "dialoguer 0.11.0",
- "dirs-2",
  "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "futures-util",
  "graphql_client",
@@ -1674,14 +1644,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-2"
-version = "3.0.1"
+name = "dirs"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8ea7942b7e715ee77e0bcb03910628a08ac2669f4cc84e904e86dc5e347f4"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "libc",
- "redox_users 0.2.0",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1692,6 +1660,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.5",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1911,31 +1891,9 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14e0b79235da57db6b6c2beed9af6e5de867d63a973ae3e91910ddc33ba40bc0"
 dependencies = [
- "dirs",
+ "dirs 1.0.5",
  "lazy_static",
  "pwd",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
 ]
 
 [[package]]
@@ -2023,12 +1981,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -3142,12 +3094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,6 +3294,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
@@ -3624,19 +3576,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3681,21 +3620,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -3728,15 +3652,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3791,18 +3706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26"
-dependencies = [
- "argon2rs",
- "failure",
- "rand 0.4.6",
- "redox_syscall 0.1.57",
 ]
 
 [[package]]
@@ -4167,12 +4070,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4.35"
 clap = { version = "4.5.6", features = ["derive","env"] }
 console = "0.15.5"
 dialoguer = "0.11.0"
-dirs-2 = "3.0.1"
+dirs = "5.0.1"
 dotenvy = "0.15.0"
 enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
 error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }

--- a/brane-cli/src/utils.rs
+++ b/brane-cli/src/utils.rs
@@ -176,7 +176,7 @@ pub fn determine_kind(path: &Path) -> Result<PackageKind, UtilError> {
 
 
 
-/// **Edited: uses dirs_2 instead of appdirs and returns UtilErrors when it goes wrong.**
+/// **Edited: uses dirs instead of appdirs and returns UtilErrors when it goes wrong.**
 ///
 /// Returns the path of the configuration directory. Is guaranteed to be an absolute path when it returns successfully (but _not_ that it also exists!).
 ///
@@ -184,7 +184,7 @@ pub fn determine_kind(path: &Path) -> Result<PackageKind, UtilError> {
 /// The path of the Brane configuration directory if successful, or a UtilError otherwise.
 pub fn get_config_dir() -> Result<PathBuf, UtilError> {
     // Try to get the user directory
-    let user = match dirs_2::config_dir() {
+    let user = match dirs::config_dir() {
         Some(user) => user,
         None => {
             return Err(UtilError::UserConfigDirNotFound);
@@ -278,7 +278,7 @@ pub fn ensure_history_file(create: bool) -> Result<PathBuf, UtilError> {
 /// A PathBuf with the absolute path that is guaranteed to exist, or an UtilError otherwise.
 pub fn get_data_dir() -> Result<PathBuf, UtilError> {
     // Try to get the user directory
-    let user = match dirs_2::data_local_dir() {
+    let user = match dirs::data_local_dir() {
         Some(user) => user,
         None => {
             return Err(UtilError::UserLocalDataDirNotFound);

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -17,7 +17,7 @@ console = "0.15.5"
 dialoguer = "0.11.0"
 diesel = { version = "2.1.0", features = ["sqlite"] }
 diesel_migrations = "2.1.0"
-dirs-2 = "3.0.0"
+dirs = "5.0.0"
 dotenvy = "0.15.0"
 eflint-to-json = { git = "https://github.com/epi-project/policy-reasoner" }
 enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -15,7 +15,7 @@ bollard = "0.14.0"
 clap = { version = "4.5.6", features = ["derive","env"] }
 console = "0.15.5"
 dialoguer = "0.11.0"
-diesel = { version = "2.1.0", features = ["sqlite"] }
+diesel = { version = "2.2.3", features = ["sqlite"] }
 diesel_migrations = "2.1.0"
 dirs = "5.0.0"
 dotenvy = "0.15.0"

--- a/brane-ctl/src/wizard.rs
+++ b/brane-ctl/src/wizard.rs
@@ -26,7 +26,7 @@ use brane_cfg::node::{self, NodeConfig, NodeKind, NodeSpecificConfig};
 use brane_cfg::proxy::{ForwardConfig, ProxyConfig, ProxyProtocol};
 use brane_shr::input::{confirm, input, input_map, input_path, select, FileHistory};
 use console::style;
-use dirs_2::config_dir;
+use dirs::config_dir;
 use enum_debug::EnumDebug as _;
 use log::{debug, info};
 use specifications::address::Address;

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -44,7 +44,6 @@ specifications = { path = "../specifications" }
 
 [dev-dependencies]
 clap = { version = "4.4.0", features = ["derive"] }
-dirs-2 = "3.0.0"
 humanlog = { git = "https://github.com/Lut99/humanlog-rs", tag = "v0.1.0" }
 lazy_static = "1.4.0"
 


### PR DESCRIPTION
dirs_2:
The old one is not updated in four years and it depends on the
unmaintained failure crate.

It still compiles, the breaking changes seem irrelevant.

Diesel:
Updated the minimal version as to not include a recent vulnerable version.