### PR TITLE
Clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v3.0.0" 
 transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.2.0" }
 names = { git = "https://github.com/Lut99/names-rs", tag = "v0.1.0", default-features = false, features = [ "rand", "three-lowercase" ]}
 download = { git = "https://github.com/Lut99/download-rs", tag = "v0.1.0", default-features = false, features = ["download"] }
+
+[workspace.lints.clippy]
+result_large_err = { level = "allow", priority = 1 }
+suspicious = "deny"

--- a/brane-api/Cargo.toml
+++ b/brane-api/Cargo.toml
@@ -42,3 +42,6 @@ brane-cfg      = { path = "../brane-cfg" }
 brane-prx      = { path = "../brane-prx" }
 brane-shr      = { path = "../brane-shr" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-api/src/main.rs
+++ b/brane-api/src/main.rs
@@ -94,7 +94,7 @@ async fn main() {
     // Configure Scylla.
     debug!("Connecting to scylla...");
     let scylla = match SessionBuilder::new()
-        .known_node(&central.services.aux_scylla.address.to_string())
+        .known_node(central.services.aux_scylla.address.to_string())
         .connection_timeout(Duration::from_secs(3))
         .build()
         .await

--- a/brane-api/src/schema.rs
+++ b/brane-api/src/schema.rs
@@ -66,14 +66,12 @@ pub struct Query;
 
 #[graphql_object(context = Context)]
 impl Query {
-    ///
     #[allow(non_snake_case)]
     async fn apiVersion() -> &'static str {
         info!("Handling GRAPHQL on '/graphql' (i.e., get API version)");
         env!("CARGO_PKG_VERSION")
     }
 
-    ///
     async fn packages(name: Option<String>, version: Option<String>, term: Option<String>, context: &Context) -> FieldResult<Vec<Package>> {
         info!("Handling GRAPHQL on '/graphql' (i.e., get packages list)");
         let scylla = context.scylla.clone();
@@ -153,13 +151,11 @@ pub struct Mutations;
 
 #[graphql_object(context = Context)]
 impl Mutations {
-    ///
     async fn login(_username: String, _password: String, _context: &Context) -> FieldResult<String> {
         info!("Handling GRAPHQL on '/graphql' (i.e., login)");
         todo!();
     }
 
-    ///
     async fn unpublish_package(name: String, version: String, context: &Context) -> FieldResult<&str> {
         info!("Handling GRAPHQL on '/graphql' (i.e., unpublish package)");
         let scylla = context.scylla.clone();

--- a/brane-ast/Cargo.toml
+++ b/brane-ast/Cargo.toml
@@ -22,3 +22,6 @@ uuid = { version = "1.7.0", features = ["serde", "v4"] }
 brane-dsl = { path = "../brane-dsl" }
 brane-shr = { path = "../brane-shr" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-ast/src/edgebuffer.rs
+++ b/brane-ast/src/edgebuffer.rs
@@ -901,6 +901,8 @@ impl EdgeBuffer {
         };
 
         // Find the end of the buffer
+        // Clippy: Hash of EdgeBufferNodePtr is not mutable
+        #[allow(clippy::mutable_key_type)]
         let mut done: HashSet<EdgeBufferNodePtr> = HashSet::with_capacity(32);
         let mut end: EdgeBufferNodePtr = start.clone();
         loop {
@@ -979,6 +981,9 @@ impl EdgeBuffer {
     /// # Returns
     /// Whether or not this buffer fully returns (true) or not (false).
     pub fn fully_returns(&self) -> bool {
+        // Clippy: EdgeBufferNodePtr hash implementation only hashes the pointer, not the content
+        // of the key, so the hash of the pointer should stay consistent.
+        #[allow(clippy::mutable_key_type)]
         let mut done: HashSet<EdgeBufferNodePtr> = HashSet::new();
 
         // Iterate as long as we can

--- a/brane-ast/src/traversals/print/ast_unresolved.rs
+++ b/brane-ast/src/traversals/print/ast_unresolved.rs
@@ -192,6 +192,8 @@ pub fn pass_f_edges(writer: &mut impl Write, f_edges: &HashMap<usize, EdgeBuffer
 ///
 /// # Returns
 /// Nothing, but does print the buffer to stdout.
+// Clippy: Hash of EdgeBufferNodePtr is not mutable
+#[allow(clippy::mutable_key_type)]
 pub fn pass_edges(
     writer: &mut impl Write,
     edges: &EdgeBuffer,
@@ -224,6 +226,8 @@ pub fn pass_edges(
                     },
                     EdgeBufferNodeLink::Branch(true_branch, false_branch, next) => {
                         // Add next to a copy of the hashset
+                        // Clippy: Hash of EdgeBufferNodePtr is not mutable
+                        #[allow(clippy::mutable_key_type)]
                         let mut nested_stop: HashSet<EdgeBufferNodePtr> = stop.clone();
                         if let Some(next) = next {
                             nested_stop.insert(next.clone());
@@ -253,6 +257,8 @@ pub fn pass_edges(
                     },
                     EdgeBufferNodeLink::Parallel(branches, join) => {
                         // Add join to a copy of the hashset
+                        // Clippy: Hash of EdgeBufferNodePtr is not mutable
+                        #[allow(clippy::mutable_key_type)]
                         let mut nested_stop: HashSet<EdgeBufferNodePtr> = stop.clone();
                         nested_stop.insert(join.clone());
 
@@ -270,6 +276,8 @@ pub fn pass_edges(
                     },
                     EdgeBufferNodeLink::Loop(cond, body, next) => {
                         // Add next to a copy of the hashset
+                        // Clippy: Hash of EdgeBufferNodePtr is not mutable
+                        #[allow(clippy::mutable_key_type)]
                         let mut nested_stop: HashSet<EdgeBufferNodePtr> = stop.clone();
                         if let Some(next) = next {
                             nested_stop.insert(next.clone());
@@ -306,7 +314,7 @@ pub fn pass_edges(
         },
     }
 
-    // DOne
+    // Done
     Ok(())
 }
 

--- a/brane-ast/src/traversals/workflow_resolve.rs
+++ b/brane-ast/src/traversals/workflow_resolve.rs
@@ -161,6 +161,8 @@ fn update_link(edge: &mut Edge, index: usize) {
 ///
 /// # Returns
 /// Nothing, but does add the edges in the `target` structure.
+// Clippy: Hash of EdgeBufferNodePtr is not mutable
+#[allow(clippy::mutable_key_type)]
 fn pass_edges(edges: EdgeBuffer, target: &mut Vec<Edge>, map: &mut HashMap<EdgeBufferNodePtr, usize>, offset: usize) {
     // Early quit if there's nothing to compile
     let mut edges_start: EdgeBufferNodePtr = match edges.start() {

--- a/brane-cc/Cargo.toml
+++ b/brane-cc/Cargo.toml
@@ -37,3 +37,6 @@ expanduser = "1.2.2"
 [dependencies.openssl-sys]
 version = "0.9.102"
 features = ["vendored"]
+
+[lints]
+workspace = true

--- a/brane-cfg/Cargo.toml
+++ b/brane-cfg/Cargo.toml
@@ -19,3 +19,6 @@ tokio = { version = "1.38.0", features = [] }
 x509-parser = "0.15.0"
 
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-cli-c/Cargo.toml
+++ b/brane-cli-c/Cargo.toml
@@ -39,3 +39,6 @@ specifications = { path = "../specifications" }
 [dependencies.openssl-sys]
 version = "0.9.102"
 features = ["vendored"]
+
+[lints]
+workspace = true

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -85,6 +85,8 @@ clap_complete = "4.5.8"
 version = "0.9.102"
 features = ["vendored"]
 
-
 [features]
 print_exec_path = [ "brane-exe/print_exec_path" ]
+
+[lints]
+workspace = true

--- a/brane-cli/src/repl.rs
+++ b/brane-cli/src/repl.rs
@@ -273,7 +273,7 @@ async fn remote_repl(
         match rl.readline(&p) {
             Ok(line) => {
                 // The command checked out, so add it to the history
-                if let Err(err) = rl.add_history_entry(&line.replace('\n', " ")) {
+                if let Err(err) = rl.add_history_entry(line.replace('\n', " ")) {
                     warn!("Failed to update REPL history: {err}");
                 }
 
@@ -361,7 +361,7 @@ async fn local_repl(
         match rl.readline(&p) {
             Ok(line) => {
                 // The command checked out, so add it to the history
-                if let Err(err) = rl.add_history_entry(&line.replace('\n', " ")) {
+                if let Err(err) = rl.add_history_entry(line.replace('\n', " ")) {
                     warn!("Failed to update REPL history: {err}");
                 }
 

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -68,5 +68,5 @@ download.workspace = true
 hex-literal = "0.4.0"
 clap = { version = "4.5.6", features = ["derive","env"] }
 
-[lints.clippy]
-result_large_err = { level = "allow", priority = 1 }
+[lints]
+workspace = true

--- a/brane-drv/Cargo.toml
+++ b/brane-drv/Cargo.toml
@@ -33,3 +33,6 @@ brane-prx = { path = "../brane-prx" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-dsl/Cargo.toml
+++ b/brane-dsl/Cargo.toml
@@ -22,3 +22,6 @@ thiserror = "1.0.40"
 
 brane-shr = { path = "../brane-shr" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-exe/Cargo.toml
+++ b/brane-exe/Cargo.toml
@@ -34,3 +34,6 @@ brane-shr = { path = "../brane-shr" }
 [features]
 print_exec_path = []
 test_logging    = []
+
+[lints]
+workspace = true

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -38,3 +38,6 @@ brane-prx = { path = "../brane-prx" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-let/Cargo.toml
+++ b/brane-let/Cargo.toml
@@ -30,3 +30,6 @@ yaml-rust = { version = "0.8", package = "yaml-rust2" }
 brane-ast = { path = "../brane-ast" }
 brane-exe = { path = "../brane-exe" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-log/Cargo.toml
+++ b/brane-log/Cargo.toml
@@ -29,3 +29,6 @@ serde_json = "1.0"
 time = { version = "0.3.0", features = ["formatting"] }
 tokio = { version = "1.0.0", features = ["full"] }
 warp = "0.3.0"
+
+[lints]
+workspace = true

--- a/brane-plr/Cargo.toml
+++ b/brane-plr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brane-plr"
+rust-version = "1.74.1"
 edition = "2021"
-rust-version = "1.74"
 version.workspace = true
 repository.workspace = true
 authors.workspace = true
@@ -30,3 +30,6 @@ brane-prx = { path = "../brane-prx" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-plr/src/context.rs
+++ b/brane-plr/src/context.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    08 Feb 2024, 15:24:59
 //  Last edited:
-//    08 Feb 2024, 15:28:54
+//    25 Nov 2024, 09:47:53
 //  Auto updated?
 //    Yes
 //
@@ -20,6 +20,23 @@ use brane_prx::client::ProxyClient;
 use parking_lot::Mutex;
 
 
+/***** TYPES *****/
+/// Defines a single "workflow" state of the planner.
+///
+/// This is used in the [`Context::state`], which represents sessions of per-snippet workflow
+/// planning. This is used when REPL'ing a workflow, as every snippet needs to be planned
+/// individually but relies on where any intermediate results are generated in previous snippets.
+/// [`Context::state`] keeps track of the locations of these intermediate results, and this type
+/// defines every such session.
+///
+/// A session is simply a pair of the last time it was accessed (stale sessions g et removed by the
+/// garbage collector) and a map of intermediate results names to the domain where they are found.
+pub type Session = (Instant, HashMap<String, String>);
+
+
+
+
+
 /***** LIBRARY *****/
 /// The shared context for all paths in the planner server.
 #[derive(Debug)]
@@ -30,5 +47,5 @@ pub struct Context {
     pub proxy: ProxyClient,
 
     /// A map of previously planned snippets.
-    pub state: Mutex<HashMap<String, (Instant, HashMap<String, String>)>>,
+    pub state: Mutex<HashMap<String, Session>>,
 }

--- a/brane-plr/src/main.rs
+++ b/brane-plr/src/main.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    17 Oct 2022, 17:27:16
 //  Last edited:
-//    08 Feb 2024, 17:12:35
+//    25 Nov 2024, 09:48:49
 //  Auto updated?
 //    Yes
 //
@@ -29,11 +29,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use brane_cfg::info::Info as _;
 use brane_cfg::node::{CentralConfig, NodeConfig};
-use brane_plr::context::Context;
+use brane_plr::context::{Context, Session};
 use brane_plr::planner;
 use brane_prx::client::ProxyClient;
 use clap::Parser;
@@ -106,7 +106,7 @@ async fn main() {
         let proxy: ProxyClient = ProxyClient::new(central_cfg.services.prx.address());
 
         // The state of previously planned workflow snippets per-instance.
-        let state: Mutex<HashMap<String, (Instant, HashMap<String, String>)>> = Mutex::new(HashMap::new());
+        let state: Mutex<HashMap<String, Session>> = Mutex::new(HashMap::new());
 
         // Build the context
         Arc::new(Context { node_config_path: opts.node_config_path, proxy, state })

--- a/brane-prx/Cargo.toml
+++ b/brane-prx/Cargo.toml
@@ -30,3 +30,6 @@ brane-cfg = { path = "../brane-cfg" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -33,3 +33,6 @@ brane-exe = { path = "../brane-exe" }
 brane-shr = { path = "../brane-shr" }
 brane-tsk = { path = "../brane-tsk" }
 specifications = { path = "../specifications" }
+
+[lints]
+workspace = true

--- a/brane-reg/src/data.rs
+++ b/brane-reg/src/data.rs
@@ -244,8 +244,7 @@ pub struct AccessDataRequest {
     ///   - `usize::MAX` means main function (workflow.graph)
     ///   - otherwise, index into function table (workflow.funcs[...])
     /// - `1`: Pointer to the instruction (Edge) within the function indicated by `0`.
-    /// Empty if the requested dataset is the
-    /// result of the workflow
+    /// - Empty if the requested dataset is the result of the workflow
     pub task_id:  Option<ProgramCounter>,
 }
 

--- a/brane-shr/Cargo.toml
+++ b/brane-shr/Cargo.toml
@@ -32,3 +32,6 @@ specifications = { path = "../specifications" }
 [dev-dependencies]
 getrandom = "0.2.8"
 tempfile = "3.10.1"
+
+[lints]
+workspace = true

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -52,3 +52,6 @@ lazy_static = "1.4.0"
 
 # [build-dependencies]
 # tonic-build = "0.8"
+
+[lints]
+workspace = true

--- a/overview/Cargo.toml
+++ b/overview/Cargo.toml
@@ -7,3 +7,6 @@ version.workspace = true
 repository.workspace = true
 authors.workspace = true
 license.workspace = true
+
+[lints]
+workspace = true

--- a/overview/src/lib.rs
+++ b/overview/src/lib.rs
@@ -38,7 +38,7 @@
 //!   - `brane-job`: Implements the _worker_ service in a Brane instance, which takes events emitted by the driver and executes them on the local domain where it is running.
 //!   - `brane-reg`: Implements the _local registry_ service in a Brane instance, which can be used by other services to query domain-local information of the instance.
 //!   - `brane-prx`: Implement the _proxy_ service in a Brane instance, which interface with the [BFC Framework](https://github.com/epi-project/EPIF-Configurations) and can route traffic through proxies as it travels between nodes.
-//!   -` brane-log`: Unused, but used to implement a lister on Kafka channels to log events.
+//!   - `brane-log`: Unused, but used to implement a lister on Kafka channels to log events.
 //!   
 //!   **Libraries**:  
 //!   - `brane-tsk`: Implements shared code used by the Brane VM plugins.

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -33,3 +33,6 @@ strum = "0.24.0"
 strum_macros = "0.24.0"
 tonic = "0.11.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
+
+[lints]
+workspace = true


### PR DESCRIPTION
A collection of several clippy fixes.

This also denies the clippy suspicious code lint collection by default. It will deny lints like the mutable key types.

This might seem counterintuitive at first, but even though that code was sound, the comment that explicitly allows that code is good documentation in my opinion. It does indeed look suspicious.

TODO:
 - [x] Fix mutable key types
 - [x] Fix complicated types
