### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,30 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    # Limit is arbitrary, but having a slight limit helps keeps stuff managable
+    # Limit is arbitrary, but having a slight limit helps keeps stuff manageable
     open-pull-requests-limit: 5
     groups:
       backwards-compatible:
         update-types:
           - "patch"
           - "minor"
+    # Okay this might seem odd, but right now Dependabot does not respect
+    # minimal versions and attempts to update the minimal version at every
+    # update. We can circumvent this by telling to only every update lockfiles,
+    # however this would be incorrect for major versions. To make matters worse,
+    # working around this problem by making two separate disjoint rules for major
+    # and minor/patch will not work either, as it will refuse because Dependabot
+    # is unable to recognize that they are in fact disjoint.
+    #
+    # The most sane compromise is to let Dependabot only handle version updates
+    # for patch and minor versions, and keep track of major version updates by
+    # some other means.
+    #
+    # Relevant open issues:
+    # - Incorrect manifest behaviour: https://github.com/Dependabot/Dependabot-core/issues/4009
+    # - Disjoint overlapping rules: https://github.com/Dependabot/Dependabot-core/issues/10160
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    versioning-strategy: "lockfile-only"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,18 +17,3 @@ updates:
         update-types:
           - "patch"
           - "minor"
-
-  # Cargo security update
-  - package-ecosystem: cargo
-    directory: /
-    schedule:
-      # Very frequent checks for security updates
-      interval: daily
-    # Never let spam converns prevent security updates
-    open-pull-requests-limit: 0
-    ignore:
-      # Ignore all version updates
-      update-types:
-        - "version-update:patch"
-        - "version-update:minor"
-        - "version-update:major"


### PR DESCRIPTION
Okay, so apparently Dependabot had changed since I last used it, which I did not notice as I don't have full access to the repo. Some Dependabot settings can now be configured in the admin panel.

@Lut99: Could you enable the following settings in `Settings > Code Security`?

Under Dependabot:

- Dependabot alerts
- Dependabot security updates
- Dependabot version updates
- Dependabot on Actions runners

It looks like that last setting is why the Dependabot file was inert.

Additionally, could you give me access to the security panel on the repo, so I can see the incoming alerts.

Since the Dependabot settings in the interface can take care of security updates now, we can remove that part from the configuration as it would be redundant. This PR removes that section.

These can now be separately handled in the GitHub settings, after which they are coupled with the Dependabot alerts.

Fixes: #141 

