### PR TITLE
chore(cargo): Set default run for packages with multiple binaries

### DIFF
--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -4,10 +4,16 @@ version = { workspace = true }
 authors = { workspace = true }
 edition = "2021"
 rust-version = "1.74.1"
+default-run = "brane"
 
 [[bin]]
 name = "brane"
 path = "src/main.rs"
+
+[[bin]]
+name = "brane-completions"
+path = "src/completions.rs"
+doc = false
 
 [dependencies]
 anyhow = "1.0.66"
@@ -81,8 +87,3 @@ features = ["vendored"]
 
 [features]
 print_exec_path = [ "brane-exe/print_exec_path" ]
-
-[[bin]]
-name = "brane-completions"
-path = "src/completions.rs"
-doc = false

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -4,10 +4,16 @@ version = { workspace = true }
 edition = "2021"
 authors = [ "Tim Müller" ]
 rust-version = "1.74.1"
+default-run = "branectl"
 
 [[bin]]
 name = "branectl"
 path = "src/main.rs"
+
+[[bin]]
+name = "branectl-completions"
+path = "src/completions.rs"
+doc = false
 
 [dependencies]
 base64ct = "1.6.0"
@@ -62,8 +68,3 @@ clap = { version = "4.5.6", features = ["derive","env"] }
 
 [lints.clippy]
 result_large_err = { level = "allow", priority = 1 }
-
-[[bin]]
-name = "branectl-completions"
-path = "src/completions.rs"
-doc = false


### PR DESCRIPTION
Without this, you have to type `--bin brane` or `--bin branectl` every time.
