### PR TITLE
fix(make): Replace list with dict in BuilderTarget src_deps

### DIFF
--- a/make.py
+++ b/make.py
@@ -2941,7 +2941,7 @@ class BuilderTarget(Target):
         """
 
         # Set the super fields
-        super().__init__(name, [], [], [], deps, description)
+        super().__init__(name, [], {}, [], deps, description)
 
     def _cmds(self, args: argparse.Namespace) -> typing.List[Command]:
         """


### PR DESCRIPTION
Due to an error the maker was broken and could not actually build targets anymore.

I would swear I not only tested this, but used to run this as my default branch for a bit.

Anyway, this should fix it
