### PR TITLE
chore: Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.2"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf97ee7261bb708fa3402fa9c17a54b70e90e3cb98afb3dc8999d5512cb03f94"
+checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
 dependencies = [
  "diesel_derives",
  "libsqlite3-sys",


### PR DESCRIPTION
I seem to have missed the lock file during the diesel upgrade.

This highlights another "problem" with CI, where it refuses to run the rest of the CI if the lockfile is out of date.

It should definitely not completely pass, but it would be nice if the rest still ran.

Added these items to the tracking issue #77
