### PR TITLE
chore(dependabot): Group together policy reasoner updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,24 @@ updates:
     # Limit is arbitrary, but having a slight limit helps keeps stuff manageable
     open-pull-requests-limit: 5
     groups:
+      # The policy reasoner functions as a whole, lets attempt to update it as a whole
+      policy-reasoner:
+        patterns:
+          - "auth-resolver"
+          - "deliberation"
+          - "eflint-to-json"
+          - "policy"
+          - "reasonerconn"
+          - "srv"
+          - "state-resolver"
+          - "workflow"
+          - "audit-logger"
+          - "nested-cli-parser"
+          # Tools
+          - "checker-client"
+          - "key-manager"
+          - "policy-builder"
+
       backwards-compatible:
         update-types:
           - "patch"


### PR DESCRIPTION
This should in theory group together all the policy reasoner updates, as they should be updated in tandem.

I don't really have a way to check if this is going to work, nor do I have the access to see if it did afterwards.

@lut99, Could you check if this makes sense?

The documentation on this particular setting can be found here:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-1

After merging, you can see in the same panel where you enabled it if the file is properly parsed.
