### PR TITLE
fix(cli): Implement downloading of assets with usecases

### DIFF
--- a/brane-ast/src/ast.rs
+++ b/brane-ast/src/ast.rs
@@ -23,20 +23,25 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use brane_dsl::spec::MergeStrategy;
+use brane_dsl::ParserOptions;
 use enum_debug::EnumDebug;
+use log::debug;
 use rand::Rng as _;
 use rand::distributions::Alphanumeric;
 use serde::de::{self, Deserializer, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json_any_key::any_key_map;
-use specifications::data::{AvailabilityKind, DataName};
-use specifications::package::Capability;
+use specifications::data::{AvailabilityKind, DataIndex, DataName};
+use specifications::package::{Capability, PackageIndex};
 use specifications::version::Version;
 
+use crate::errors::CompileError;
+use crate::{compile_snippet, CompileResult};
 use crate::data_type::DataType;
 use crate::func_id::FunctionId;
 use crate::locations::{Location, Locations};
+use crate::state::CompileState;
 
 
 /***** CONSTANTS *****/
@@ -60,10 +65,6 @@ lazy_static!(
 fn generate_random_workflow_id() -> String {
     format!("workflow-{}", rand::thread_rng().sample_iter(Alphanumeric).take(8).map(char::from).collect::<String>())
 }
-
-
-
-
 
 /***** TOPLEVEL *****/
 /// Defines a Workflow, which is meant to be an 'executable but reasonable' graph.
@@ -122,6 +123,88 @@ impl Workflow {
         }
     }
 
+    /// Compiles the given worfklow string to a Workflow.
+    ///
+    /// # Arguments
+    /// - `state`: The CompileState to compile with (and to update).
+    /// - `source`: The collected source string for now. This will be updated with the new snippet.
+    /// - `pindex`: The PackageIndex to resolve package imports with.
+    /// - `dindex`: The DataIndex to resolve data instantiations with.
+    /// - `user`: If given, then this is some tentative identifier of the user receiving the final workflow result.
+    /// - `options`: The ParseOptions to use.
+    /// - `what`: A string describing what we're parsing (e.g., a filename, stdin, ...).
+    /// - `snippet`: The actual snippet to parse.
+    ///
+    /// # Returns
+    /// A new Workflow that is the compiled and executable version of the given snippet.
+    ///
+    /// # Errors
+    /// This function errors if the given string was not a valid workflow. If that's the case, it's also pretty-printed to stdout with source context.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_source(
+        state: &mut CompileState,
+        source: &mut String,
+        pindex: &PackageIndex,
+        dindex: &DataIndex,
+        user: Option<&str>,
+        options: &ParserOptions,
+        what: impl AsRef<str>,
+        snippet: impl AsRef<str>,
+    ) -> Result<Self, crate::errors::CompileError> {
+        let what: &str = what.as_ref();
+        let snippet: &str = snippet.as_ref();
+
+        // Append the source with the snippet
+        source.push_str(snippet);
+        source.push('\n');
+
+        // Compile the snippet, possibly fetching new ones while at it
+        let workflow: Workflow = match compile_snippet(state, snippet.as_bytes(), pindex, dindex, options) {
+            CompileResult::Workflow(mut wf, warns) => {
+                // Print any warnings to stdout
+                for w in warns {
+                    w.prettyprint(what, &source);
+                }
+
+                // Then, inject the username if any
+                if let Some(user) = user {
+                    debug!("Setting user '{user}' as receiver of final result");
+                    wf.user = Arc::new(Some(user.into()));
+                }
+
+                // Done
+                wf
+            },
+
+            CompileResult::Eof(err) => {
+                // Prettyprint it
+                err.prettyprint(what, &source);
+                state.offset += 1 + snippet.chars().filter(|c| *c == '\n').count();
+                return Err(CompileError::AstError { what: what.into(), errs: vec![err] });
+            },
+            CompileResult::Err(errs) => {
+                // Prettyprint them
+                for e in &errs {
+                    e.prettyprint(what, &source);
+                }
+                state.offset += 1 + snippet.chars().filter(|c| *c == '\n').count();
+                return Err(CompileError::AstError { what: what.into(), errs });
+            },
+
+            // Any others should not occur
+            _ => {
+                unreachable!();
+            },
+        };
+        debug!("Compiled to workflow:\n\n");
+        if log::max_level() == log::LevelFilter::Debug {
+            crate::traversals::print::ast::do_traversal(&workflow, std::io::stdout()).unwrap();
+        }
+
+        // Return
+        Ok(workflow)
+    }
+
     // /// Returns the edge pointed to by the given PC.
     // ///
     // /// # Arguments
@@ -171,6 +254,11 @@ impl Default for Workflow {
             funcs: Arc::new(HashMap::new()),
         }
     }
+}
+
+pub struct Snippet {
+    pub lines: usize,
+    pub snippet: Workflow,
 }
 
 

--- a/brane-ast/src/errors.rs
+++ b/brane-ast/src/errors.rs
@@ -414,6 +414,7 @@ pub enum AstError {
     PruneError(PruneError),
     /// An error has occurred while flattening the AST's symbol tables.
     FlattenError(FlattenError),
+    CompileError(CompileError),
 }
 
 impl AstError {
@@ -455,6 +456,7 @@ impl AstError {
             LocationError(err) => err.prettywrite(writer, file, source),
             PruneError(err) => err.prettywrite(writer, file, source),
             FlattenError(err) => err.prettywrite(writer, file, source),
+            CompileError(err) => err.prettywrite(writer, file, source),
         }
     }
 }
@@ -504,6 +506,7 @@ impl Display for AstError {
             LocationError(err) => write!(f, "{err}"),
             PruneError(err) => write!(f, "{err}"),
             FlattenError(err) => write!(f, "{err}"),
+            CompileError(err) => write!(f,"Compile error\n: Error: {err}"),
         }
     }
 }
@@ -1077,3 +1080,25 @@ impl Display for FlattenError {
 }
 
 impl Error for FlattenError {}
+
+#[derive(Debug)]
+pub enum CompileError {
+    AstError { what: String, errs: Vec<AstError> }
+}
+
+impl Error for CompileError {}
+
+impl Display for CompileError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
+        use CompileError::*;
+        match self {
+            AstError { what, errs: _ } => write!(f, "Something went wrong during compilation of the workflow: {what}"),
+        }
+    }
+}
+
+impl CompileError {
+    pub fn prettywrite(&self, writer: impl Write, file: impl AsRef<str>, source: impl AsRef<str>) -> Result<(), std::io::Error> {
+        prettywrite_err(writer, file, source, self, &TextRange::none())
+    }
+}

--- a/brane-cli-c/src/lib.rs
+++ b/brane-cli-c/src/lib.rs
@@ -17,7 +17,6 @@
 //
 
 use std::cell::{RefCell, RefMut};
-use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fmt::Write as _;
 use std::io::Write;
@@ -32,15 +31,14 @@ use brane_ast::ast::Workflow;
 use brane_ast::state::CompileState;
 use brane_ast::traversals::print::ast;
 use brane_ast::{CompileResult, Error as AstError, ParserOptions, Warning as AstWarning};
-use brane_cli::data::download_data;
 use brane_cli::run::{InstanceVmState, initialize_instance, run_instance};
 use brane_exe::FullValue;
 use brane_tsk::api::{get_data_index, get_package_index};
 use console::style;
 use humanlog::{DebugMode, HumanLogger};
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, info, trace};
 use parking_lot::{Mutex, MutexGuard};
-use specifications::data::{AccessKind, DataIndex};
+use specifications::data::DataIndex;
 use specifications::package::PackageIndex;
 use tokio::runtime::{Builder, Runtime};
 
@@ -1214,10 +1212,12 @@ pub struct VirtualMachine {
     /// The tokio runtime handle to use for this VM
     runtime: Arc<Runtime>,
     /// The endpoint to connect to for downloading registries
+    #[allow(dead_code)]
     api_endpoint: String,
     /// The endpoint to connect to when running.
     drv_endpoint: String,
     /// The directory of certificates to use.
+    #[allow(dead_code)]
     certs_dir: String,
     /// The state of everything we need to know about the virtual machine
     state: InstanceVmState<BytesHandle, BytesHandle>,
@@ -1412,78 +1412,86 @@ pub unsafe extern "C" fn vm_run(
 ///
 /// # Panics
 /// This function may panic if the input `vm` or `result` pointed to a NULL-pointer, or if `data_dir` did not point to a valid UTF-8 string.
+///
+// TODO: Resolve this problem
+//
+/// /// <div class="warning">
+/// This function is currently broken because of ecosystem changes. See: https://github.com/epi-project/brane/issues/195
+/// </div>
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn vm_process(vm: *mut VirtualMachine, result: *const FullValue, data_dir: *const c_char) -> *const Error {
-    init_logger();
-    info!("Processing result on virtual machine...");
-    let start: Instant = Instant::now();
-
-    // Unwrap the VM
-    let vm: &mut VirtualMachine = match vm.as_mut() {
-        Some(vm) => vm,
-        None => {
-            panic!("Given VirtualMachine is a NULL-pointer");
-        },
-    };
-    // Unwrap the result
-    let result: &FullValue = match result.as_ref() {
-        Some(result) => result,
-        None => {
-            panic!("Given FullValue is a NULL-pointer");
-        },
-    };
-    // Read the string
-    let data_dir: &str = cstr_to_rust(data_dir);
-
-    // If the value is a dataset, then download the data on top of it
-    if let FullValue::Data(d) = &result {
-        debug!("FullValue is a FullValue::Data, downloading...");
-
-        // Refresh the data index and get the access list for this dataset
-        let access: HashMap<String, AccessKind> = {
-            // Get a mutable lock to do so
-            let mut dindex: MutexGuard<DataIndex> = vm.state.dindex.lock();
-
-            // Simply load it again
-            let data_endpoint: String = format!("{}/data/info", vm.api_endpoint);
-            *dindex = match vm.runtime.block_on(get_data_index(data_endpoint)) {
-                Ok(index) => index,
-                Err(e) => {
-                    let err: Box<Error> = Box::new(Error { msg: format!("Failed to refresh data index: {e}") });
-                    return Box::into_raw(err);
-                },
-            };
-
-            // Fetch the correct map
-            match dindex.get(d) {
-                Some(info) => info.access.clone(),
-                None => {
-                    let err: Box<Error> = Box::new(Error { msg: format!("Resulting dataset '{d}' is not at any location") });
-                    return Box::into_raw(err);
-                },
-            }
-        };
-
-        // Run the process funtion
-        let res: Option<AccessKind> = match vm.runtime.block_on(download_data(&vm.api_endpoint, &None, &vm.certs_dir, data_dir, d, &access)) {
-            Ok(res) => res,
-            Err(e) => {
-                let err: Box<Error> = Box::new(Error { msg: format!("Failed to download resulting data from '{}': {}", vm.api_endpoint, e) });
-                return Box::into_raw(err);
-            },
-        };
-        if let Some(AccessKind::File { path }) = res {
-            info!("Downloaded dataset to '{}'", path.display());
-        }
-    } else if matches!(result, FullValue::IntermediateResult(_)) {
-        debug!("FullValue is a FullValue::IntermediateResult, downloading...");
-
-        // Emit a warning
-        warn!("Cannot download intermediate result");
-    }
-
-    // OK, nothing to return
-    debug!("Done (processing took {:.2}s)", start.elapsed().as_secs_f32());
-    std::ptr::null()
+pub unsafe extern "C" fn vm_process(_vm: *mut VirtualMachine, _result: *const FullValue, _data_dir: *const c_char) -> *const Error {
+    todo!("vm_process: This function does know its workflow and can therefore cannot be implemented currently");
+    // init_logger();
+    // info!("Processing result on virtual machine...");
+    // let start: Instant = Instant::now();
+    //
+    // // Unwrap the VM
+    // let vm: &mut VirtualMachine = match vm.as_mut() {
+    //     Some(vm) => vm,
+    //     None => {
+    //         panic!("Given VirtualMachine is a NULL-pointer");
+    //     },
+    // };
+    // // Unwrap the result
+    // let result: &FullValue = match result.as_ref() {
+    //     Some(result) => result,
+    //     None => {
+    //         panic!("Given FullValue is a NULL-pointer");
+    //     },
+    // };
+    // // Read the string
+    // let data_dir: &str = cstr_to_rust(data_dir);
+    //
+    // // If the value is a dataset, then download the data on top of it
+    // if let FullValue::Data(d) = &result {
+    //     debug!("FullValue is a FullValue::Data, downloading...");
+    //
+    //     // Refresh the data index and get the access list for this dataset
+    //     let access: HashMap<String, AccessKind> = {
+    //         // Get a mutable lock to do so
+    //         let mut dindex: MutexGuard<DataIndex> = vm.state.dindex.lock();
+    //
+    //         // Simply load it again
+    //         let data_endpoint: String = format!("{}/data/info", vm.api_endpoint);
+    //         *dindex = match vm.runtime.block_on(get_data_index(data_endpoint)) {
+    //             Ok(index) => index,
+    //             Err(e) => {
+    //                 let err: Box<Error> = Box::new(Error { msg: format!("Failed to refresh data index: {e}") });
+    //                 return Box::into_raw(err);
+    //             },
+    //         };
+    //
+    //         // Fetch the correct map
+    //         match dindex.get(d) {
+    //             Some(info) => info.access.clone(),
+    //             None => {
+    //                 let err: Box<Error> = Box::new(Error { msg: format!("Resulting dataset '{d}' is not at any location") });
+    //                 return Box::into_raw(err);
+    //             },
+    //         }
+    //     };
+    //
+    //     #[allow(unreachable_code)]
+    //     // Run the process funtion
+    //     let res: Option<AccessKind> = match vm.runtime.block_on(download_data(&vm.api_endpoint, &None, &vm.certs_dir, data_dir, d, workflow, &access)) {
+    //         Ok(res) => res,
+    //         Err(e) => {
+    //             let err: Box<Error> = Box::new(Error { msg: format!("Failed to download resulting data from '{}': {}", vm.api_endpoint, e) });
+    //             return Box::into_raw(err);
+    //         },
+    //     };
+    //     if let Some(AccessKind::File { path }) = res {
+    //         info!("Downloaded dataset to '{}'", path.display());
+    //     }
+    // } else if matches!(result, FullValue::IntermediateResult(_)) {
+    //     debug!("FullValue is a FullValue::IntermediateResult, downloading...");
+    //
+    //     // Emit a warning
+    //     warn!("Cannot download intermediate result");
+    // }
+    //
+    // // OK, nothing to return
+    // debug!("Done (processing took {:.2}s)", start.elapsed().as_secs_f32());
+    // std::ptr::null()
 }

--- a/brane-cli/src/cli.rs
+++ b/brane-cli/src/cli.rs
@@ -578,6 +578,9 @@ pub(crate) enum WorkflowSubcommand {
         #[clap(short, long, value_names = &["address[:port]"], help = "If given, proxies any data transfers to this machine through the proxy at the given address. Irrelevant if not running remotely.")]
         proxy_addr: Option<String>,
 
+        #[clap(name = "use case")]
+        use_case: String,
+
         #[clap(short, long, help = "Create a remote REPL session to the instance you are currently logged-in to (see `brane login`)")]
         remote: bool,
         #[clap(short, long, value_names = &["uid"], help = "Attach to an existing remote session")]
@@ -625,6 +628,9 @@ pub(crate) enum WorkflowSubcommand {
     Run {
         #[clap(short, long, value_names = &["address[:port]"], help = "If given, proxies any data transfers to this machine through the proxy at the given address. Irrelevant if not running remotely.")]
         proxy_addr: Option<String>,
+
+        #[clap(name = "use case")]
+        use_case: String,
 
         #[clap(short, long, action, help = "Use Bakery instead of BraneScript")]
         bakery: bool,

--- a/brane-cli/src/data.rs
+++ b/brane-cli/src/data.rs
@@ -18,6 +18,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use brane_ast::Workflow;
 use brane_shr::fs::copy_dir_recursively_async;
 use brane_shr::utilities::is_ip_addr;
 use brane_tsk::spec::LOCALHOST;
@@ -25,7 +26,6 @@ use chrono::Utc;
 use console::{Alignment, Term, pad_str, style};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Select};
-use hyper::body::Bytes;
 use indicatif::HumanDuration;
 use prettytable::Table;
 use prettytable::format::FormatBuilder;
@@ -33,6 +33,7 @@ use rand::prelude::IteratorRandom;
 use reqwest::tls::{Certificate, Identity};
 use reqwest::{Client, ClientBuilder, Proxy, Response};
 use specifications::data::{AccessKind, AssetInfo, DataIndex, DataInfo};
+use specifications::registering::DownloadAssetRequest;
 use tempfile::TempDir;
 use tokio::fs as tfs;
 use tokio::io::AsyncWriteExt;
@@ -66,15 +67,15 @@ pub async fn download_data(
     proxy_addr: &Option<String>,
     certs_dir: impl AsRef<Path>,
     data_dir: impl AsRef<Path>,
+    use_case: String,
     name: impl AsRef<str>,
+    workflow: Workflow,
     access: &HashMap<String, AccessKind>,
 ) -> Result<Option<AccessKind>, DataError> {
     let api_endpoint: &str = api_endpoint.as_ref();
     let certs_dir: &Path = certs_dir.as_ref();
     let data_dir: &Path = data_dir.as_ref();
     let name: &str = name.as_ref();
-
-
 
     /* Step 1: Get target registry address */
     // Choose a random location to attempt to download the asset from.
@@ -85,169 +86,112 @@ pub async fn download_data(
     let location: &str = access.keys().choose(&mut rng).unwrap();
 
     // Send a GET-request to resolve that location to a delegate
-    let registry_addr: String = format!("{api_endpoint}/infra/registries/{location}");
-    let res: Response = match reqwest::get(&registry_addr).await {
-        Ok(res) => res,
-        Err(err) => {
-            return Err(DataError::RequestError { what: "registry", address: registry_addr, err });
-        },
-    };
+    let registry_addr = format!("{api_endpoint}/infra/registries/{location}");
+    let res = reqwest::get(&registry_addr).await.map_err(|err| DataError::RequestError { what: "registry", address: registry_addr.clone(), err })?;
 
     // Attempt to get its body if it was a success
     if !res.status().is_success() {
         return Err(DataError::RequestFailure { address: registry_addr, code: res.status(), message: res.text().await.ok() });
     }
-    let registry_addr: String = match res.text().await {
-        Ok(registry_addr) => registry_addr,
-        Err(err) => {
-            return Err(DataError::ResponseTextError { address: registry_addr, err });
-        },
-    };
+
+    let registry_addr: String = res.text().await.map_err(|err| DataError::ResponseTextError { address: registry_addr, err })?;
+
     debug!("Remote registry: '{}'", registry_addr);
-
-
 
     /* Step 2: Load the required certificates */
     debug!("Loading certificate for location '{}'...", location);
     let (identity, ca_cert): (Identity, Certificate) = {
         // Compute the paths
-        // let cert_dir : PathBuf = match get_active_certs_dir(location) { Ok(path) => path, Err(err) => { return Err(DataError::CertsDirError{ err }); }, };
-        let cert_dir: PathBuf = certs_dir.join(location);
-        let idfile: PathBuf = cert_dir.join("client-id.pem");
-        let cafile: PathBuf = cert_dir.join("ca.pem");
+        let cert_dir = certs_dir.join(location);
+        let idfile = cert_dir.join("client-id.pem");
+        let cafile = cert_dir.join("ca.pem");
 
         // Load the keypair for this location as an Identity file (for which we just smash 'em together and hope that works)
-        let ident: Identity = match tfs::read(&idfile).await {
-            Ok(raw) => match Identity::from_pem(&raw) {
-                Ok(identity) => identity,
-                Err(err) => {
-                    return Err(DataError::IdentityFileError { path: idfile, err });
-                },
-            },
-            Err(err) => {
-                return Err(DataError::FileReadError { what: "client identity", path: idfile, err });
-            },
-        };
+        let ident_raw = tfs::read(&idfile).await.map_err(|err| DataError::FileReadError { what: "client identity", path: idfile.clone(), err })?;
+
+        let ident = Identity::from_pem(&ident_raw).map_err(|err| DataError::IdentityFileError { path: idfile.clone(), err })?;
 
         // Load the root store for this location (also as a list of certificates)
-        let root: Certificate = match tfs::read(&cafile).await {
-            Ok(raw) => match Certificate::from_pem(&raw) {
-                Ok(root) => root,
-                Err(err) => {
-                    return Err(DataError::CertificateError { path: cafile, err });
-                },
-            },
-            Err(err) => {
-                return Err(DataError::FileReadError { what: "server cert root", path: cafile, err });
-            },
-        };
+        let raw_root = tfs::read(&cafile).await.map_err(|err| DataError::FileReadError { what: "server cert root", path: cafile.clone(), err })?;
+
+        // Load the root store for this location (also as a list of certificates)
+        let root = Certificate::from_pem(&raw_root).map_err(|err| DataError::CertificateError { path: cafile, err })?;
 
         // Return them, with the cert and key as identity
         (ident, root)
     };
 
-
-
     /* Step 3: Prepare the filesystem */
     debug!("Preparing filesystem...");
 
     // Make sure the temporary tarfile directory exists
-    let tar_dir: TempDir = match TempDir::new() {
-        Ok(tar_dir) => tar_dir,
-        Err(err) => {
-            return Err(DataError::TempDirError { err });
-        },
-    };
-    let tar_path: PathBuf = tar_dir.path().join(format!("data_{name}.tar.gz"));
+    let tar_dir = TempDir::new().map_err(|err| DataError::TempDirError { err })?;
+    let tar_path = tar_dir.path().join(format!("data_{name}.tar.gz"));
 
     // Make sure the old data path doesn't exist anymore
-    let data_path: PathBuf = data_dir.join("data");
+    let data_path = data_dir.join("data");
     if data_path.exists() {
         if !data_path.is_dir() {
             return Err(DataError::DirNotADirError { what: "target data", path: data_path });
         }
-        if let Err(err) = tfs::remove_dir_all(&data_path).await {
-            return Err(DataError::DirRemoveError { what: "target data", path: data_path, err });
-        }
+        tfs::remove_dir_all(&data_path).await.map_err(|err| DataError::DirRemoveError { what: "target data", path: data_path.clone(), err })?;
     }
-
-
 
     /* Step 4: Build the client. */
     let download_addr: String = format!("{registry_addr}/data/download/{name}");
     debug!("Sending download request to '{}'...", download_addr);
     let mut client: ClientBuilder =
         Client::builder().use_rustls_tls().add_root_certificate(ca_cert).identity(identity).tls_sni(!is_ip_addr(&download_addr));
+
     if let Some(proxy_addr) = proxy_addr {
-        client = client.proxy(match Proxy::all(proxy_addr) {
-            Ok(proxy) => proxy,
-            Err(err) => return Err(DataError::ProxyCreateError { address: proxy_addr.into(), err }),
-        });
+        client = client.proxy(Proxy::all(proxy_addr).map_err(|err| DataError::ProxyCreateError { address: proxy_addr.into(), err })?);
     }
-    let client: Client = match client.build() {
-        Ok(client) => client,
-        Err(err) => {
-            return Err(DataError::ClientCreateError { err });
-        },
-    };
+
+    let client = client.build().map_err(|err| DataError::ClientCreateError { err })?;
 
     // Send a reqwest
-    let res = match client.get(&download_addr).send().await {
-        Ok(res) => res,
-        Err(err) => {
-            return Err(DataError::RequestError { what: "download", address: download_addr, err });
-        },
-    };
+    let res = client
+        .get(&download_addr)
+        .json(&DownloadAssetRequest {
+            use_case,
+            workflow: serde_json::to_value(workflow).map_err(|err| DataError::WorkflowSerializeError { context: String::from("creating download asset request"), err })?,
+            task:     None,
+        })
+        .send()
+        .await
+        .map_err(|err| DataError::RequestError { what: "download", address: download_addr.clone(), err })?;
+
     if !res.status().is_success() {
         return Err(DataError::RequestFailure { address: download_addr, code: res.status(), message: res.text().await.ok() });
     }
 
-
-
     /* Step 5: Download the raw file in parts */
     debug!("Downloading file to '{}'...", tar_path.display());
     {
-        let mut handle: tfs::File = match tfs::File::create(&tar_path).await {
-            Ok(handle) => handle,
-            Err(err) => {
-                return Err(DataError::TarCreateError { path: tar_path, err });
-            },
-        };
+        let mut handle = tfs::File::create(&tar_path).await.map_err(|err| DataError::TarCreateError { path: tar_path.clone(), err })?;
+
         let mut stream = res.bytes_stream();
         while let Some(chunk) = stream.next().await {
             // Unwrap the chunk
-            let mut chunk: Bytes = match chunk {
-                Ok(chunk) => chunk,
-                Err(err) => {
-                    return Err(DataError::DownloadStreamError { address: download_addr, err });
-                },
-            };
+            let mut chunk = chunk.map_err(|err| DataError::DownloadStreamError { address: download_addr.clone(), err })?;
 
             // Write it to the file
-            if let Err(err) = handle.write_all_buf(&mut chunk).await {
-                return Err(DataError::TarWriteError { path: tar_path, err });
-            }
+            handle.write_all_buf(&mut chunk).await.map_err(|err| DataError::TarWriteError { path: tar_path.clone(), err })?;
         }
     }
 
-
-
     /* Step 6: Extract the tar. */
     debug!("Unpacking '{}' to '{}'...", tar_path.display(), data_path.display());
-    if let Err(err) = brane_shr::fs::unarchive_async(tar_path, &data_path).await {
-        return Err(DataError::TarExtractError { err });
-    }
-
-
+    brane_shr::fs::unarchive_async(tar_path, &data_path).await.map_err(|err| DataError::TarExtractError { err })?;
 
     /* Step 7: In the case of brane-cli, also write a DataInfo. */
-    let access: AccessKind = AccessKind::File { path: data_path };
+    let access = AccessKind::File { path: data_path };
     {
-        let info_path: PathBuf = data_dir.join("data.yml");
+        let info_path = data_dir.join("data.yml");
         debug!("Writing data info to '{}'...", info_path.display());
 
         // Populate the info itself
-        let info: DataInfo = DataInfo {
+        let info = DataInfo {
             name: name.into(),
             owners: None,
             description: None,
@@ -257,12 +201,8 @@ pub async fn download_data(
         };
 
         // Write it
-        if let Err(err) = info.to_path(&info_path) {
-            return Err(DataError::DataInfoWriteError { err });
-        }
+        info.to_path(&info_path).map_err(|err| DataError::DataInfoWriteError { err })?;
     }
-
-
 
     /* Step 7: Done */
     Ok(Some(access))
@@ -387,7 +327,7 @@ pub async fn build(file: impl AsRef<Path>, workdir: impl AsRef<Path>, _keep_file
 ///
 /// # Errors
 /// This function may error if the download failed for any reason.
-pub async fn download(names: Vec<String>, locs: Vec<String>, proxy_addr: &Option<String>, force: bool) -> Result<(), DataError> {
+pub async fn download(names: Vec<String>, locs: Vec<String>, _proxy_addr: &Option<String>, force: bool) -> Result<(), DataError> {
     // Parse the locations into a map
     let mut locations: HashMap<String, String> = HashMap::with_capacity(locs.len());
     for l in locs {
@@ -484,35 +424,40 @@ pub async fn download(names: Vec<String>, locs: Vec<String>, proxy_addr: &Option
             Some(access) => access.clone(),
             None => {
                 // Attempt to download it instead
+                // TODO: We need to generate a minimal workflow to only check if an download is
+                // allowed.
+                //
 
-                // Get the certificate path
-                let certs_dir: PathBuf = match InstanceInfo::get_active_name() {
-                    Ok(name) => match InstanceInfo::get_instance_path(&name) {
-                        Ok(path) => path.join("certs"),
-                        Err(err) => {
-                            return Err(DataError::InstancePathError { name, err });
-                        },
-                    },
-                    Err(err) => {
-                        return Err(DataError::ActiveInstanceReadError { err });
-                    },
-                };
+                todo!("We need to generate a data transfer only workflow");
 
-                // Get the path to download it to
-                let data_dir: PathBuf = match ensure_dataset_dir(&name, true) {
-                    Ok(dir) => dir,
-                    Err(err) => {
-                        return Err(DataError::DatasetDirError { name, err });
-                    },
-                };
-
-                // Run the download
-                match download_data(instance_info.api.to_string(), proxy_addr, certs_dir, data_dir, &name, &access).await? {
-                    Some(access) => access,
-                    None => {
-                        return Err(DataError::UnavailableDataset { name, locs: info.access.keys().cloned().collect() });
-                    },
-                }
+                // // Get the certificate path
+                // let certs_dir: PathBuf = match InstanceInfo::get_active_name() {
+                //     Ok(name) => match InstanceInfo::get_instance_path(&name) {
+                //         Ok(path) => path.join("certs"),
+                //         Err(err) => {
+                //             return Err(DataError::InstancePathError { name, err });
+                //         },
+                //     },
+                //     Err(err) => {
+                //         return Err(DataError::ActiveInstanceReadError { err });
+                //     },
+                // };
+                //
+                // // Get the path to download it to
+                // let data_dir: PathBuf = match ensure_dataset_dir(&name, true) {
+                //     Ok(dir) => dir,
+                //     Err(err) => {
+                //         return Err(DataError::DatasetDirError { name, err });
+                //     },
+                // };
+                //
+                // // Run the download
+                // match download_data(instance_info.api.to_string(), proxy_addr, certs_dir, data_dir, &name, workflow, &access).await? {
+                //     Some(access) => access,
+                //     None => {
+                //         return Err(DataError::UnavailableDataset { name, locs: info.access.keys().cloned().collect() });
+                //     },
+                // }
             },
         };
 

--- a/brane-cli/src/errors.rs
+++ b/brane-cli/src/errors.rs
@@ -778,6 +778,7 @@ pub enum DataError {
     ConfirmationError { err: dialoguer::Error },
     /// Failed to remove the dataset's directory
     RemoveError { path: PathBuf, err: std::io::Error },
+    WorkflowSerializeError { context: String, err: serde_json::Error },
 }
 impl Display for DataError {
     #[inline]
@@ -851,6 +852,7 @@ impl Display for DataError {
             // DatasetDirError{ .. }   => write!(f, "Failed to get to-be-removed dataset directory: {}", err),
             ConfirmationError { .. } => write!(f, "Failed to ask the user (you) for confirmation before removing a dataset"),
             RemoveError { path, .. } => write!(f, "Failed to remove dataset directory '{}'", path.display()),
+            WorkflowSerializeError { context, .. } => write!(f, "Could not serialize workflow when: {context}"),
         }
     }
 }
@@ -910,6 +912,7 @@ impl Error for DataError {
             // DatasetDirError{ .. } => None,
             ConfirmationError { .. } => None,
             RemoveError { err, .. } => Some(err),
+            WorkflowSerializeError { err, .. } => Some(err),
         }
     }
 }
@@ -1391,7 +1394,7 @@ pub enum RunError {
     SessionCreateError { address: String, err: tonic::Status },
 
     /// An error occurred while compile the given snippet. It will already have been printed to stdout.
-    CompileError { what: String, errs: Vec<brane_ast::Error> },
+    CompileError(brane_ast::errors::CompileError),
     /// Failed to serialize the compiled workflow.
     WorkflowSerializeError { err: serde_json::Error },
     /// Requesting a command failed

--- a/brane-cli/src/instance.rs
+++ b/brane-cli/src/instance.rs
@@ -83,6 +83,7 @@ pub struct InstanceInfo {
     /// A username to send with workflow requests as receiver of the final result.
     pub user: String,
 }
+
 impl InstanceInfo {
     /// Reads this InstanceInfo from the active instance's directory in the local configuration directory.
     ///

--- a/brane-cli/src/main.rs
+++ b/brane-cli/src/main.rs
@@ -496,10 +496,11 @@ async fn run(options: Cli) -> Result<(), CliError> {
                     return Err(CliError::CheckError { err });
                 };
             },
-            WorkflowSubcommand::Repl { proxy_addr, bakery, clear, remote, attach, profile, docker_socket, client_version, keep_containers } => {
+            WorkflowSubcommand::Repl { proxy_addr, use_case, bakery, clear, remote, attach, profile, docker_socket, client_version, keep_containers } => {
                 if let Err(err) = repl::start(
                     proxy_addr,
                     remote,
+                    use_case,
                     attach,
                     if bakery { Language::Bakery } else { Language::BraneScript },
                     clear,
@@ -512,10 +513,11 @@ async fn run(options: Cli) -> Result<(), CliError> {
                     return Err(CliError::ReplError { err });
                 };
             },
-            WorkflowSubcommand::Run { proxy_addr, bakery, file, dry_run, remote, profile, docker_socket, client_version, keep_containers } => {
+            WorkflowSubcommand::Run { proxy_addr, use_case, bakery, file, dry_run, remote, profile, docker_socket, client_version, keep_containers } => {
                 if let Err(err) = run::handle(
                     proxy_addr,
                     if bakery { Language::Bakery } else { Language::BraneScript },
+                    use_case,
                     file,
                     dry_run,
                     remote,

--- a/brane-cli/src/run.rs
+++ b/brane-cli/src/run.rs
@@ -19,8 +19,9 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
+use brane_ast::ast::Snippet;
 use brane_ast::state::CompileState;
-use brane_ast::{CompileResult, ParserOptions, Workflow, compile_snippet};
+use brane_ast::{ParserOptions, Workflow};
 use brane_dsl::Language;
 use brane_exe::FullValue;
 use brane_exe::dummy::{DummyVm, Error as DummyVmError};
@@ -41,94 +42,6 @@ pub use crate::errors::RunError as Error;
 use crate::instance::InstanceInfo;
 use crate::utils::{ensure_datasets_dir, ensure_packages_dir, get_datasets_dir, get_packages_dir};
 use crate::vm::OfflineVm;
-
-
-/***** HELPER FUNCTIONS *****/
-/// Compiles the given worfklow string to a Workflow.
-///
-/// # Arguments
-/// - `state`: The CompileState to compile with (and to update).
-/// - `source`: The collected source string for now. This will be updated with the new snippet.
-/// - `pindex`: The PackageIndex to resolve package imports with.
-/// - `dindex`: The DataIndex to resolve data instantiations with.
-/// - `user`: If given, then this is some tentative identifier of the user receiving the final workflow result.
-/// - `options`: The ParseOptions to use.
-/// - `what`: A string describing what we're parsing (e.g., a filename, stdin, ...).
-/// - `snippet`: The actual snippet to parse.
-///
-/// # Returns
-/// A new Workflow that is the compiled and executable version of the given snippet.
-///
-/// # Errors
-/// This function errors if the given string was not a valid workflow. If that's the case, it's also pretty-printed to stdout with source context.
-
-#[allow(clippy::too_many_arguments)]
-fn compile(
-    state: &mut CompileState,
-    source: &mut String,
-    pindex: &PackageIndex,
-    dindex: &DataIndex,
-    user: Option<&str>,
-    options: &ParserOptions,
-    what: impl AsRef<str>,
-    snippet: impl AsRef<str>,
-) -> Result<Workflow, Error> {
-    let what: &str = what.as_ref();
-    let snippet: &str = snippet.as_ref();
-
-    // Append the source with the snippet
-    source.push_str(snippet);
-    source.push('\n');
-
-    // Compile the snippet, possibly fetching new ones while at it
-    let workflow: Workflow = match compile_snippet(state, snippet.as_bytes(), pindex, dindex, options) {
-        CompileResult::Workflow(mut wf, warns) => {
-            // Print any warnings to stdout
-            for w in warns {
-                w.prettyprint(what, &source);
-            }
-
-            // Then, inject the username if any
-            if let Some(user) = user {
-                debug!("Setting user '{user}' as receiver of final result");
-                wf.user = Arc::new(Some(user.into()));
-            }
-
-            // Done
-            wf
-        },
-
-        CompileResult::Eof(err) => {
-            // Prettyprint it
-            err.prettyprint(what, &source);
-            state.offset += 1 + snippet.chars().filter(|c| *c == '\n').count();
-            return Err(Error::CompileError { what: what.into(), errs: vec![err] });
-        },
-        CompileResult::Err(errs) => {
-            // Prettyprint them
-            for e in &errs {
-                e.prettyprint(what, &source);
-            }
-            state.offset += 1 + snippet.chars().filter(|c| *c == '\n').count();
-            return Err(Error::CompileError { what: what.into(), errs });
-        },
-
-        // Any others should not occur
-        _ => {
-            unreachable!();
-        },
-    };
-    debug!("Compiled to workflow:\n\n");
-    if log::max_level() == log::LevelFilter::Debug {
-        brane_ast::traversals::print::ast::do_traversal(&workflow, std::io::stdout()).unwrap();
-    }
-
-    // Return
-    Ok(workflow)
-}
-
-
-
 
 
 /***** AUXILLARY FUNCTIONS *****/
@@ -348,6 +261,8 @@ pub async fn process_instance(
     proxy_addr: &Option<String>,
     certs_dir: impl AsRef<Path>,
     datasets_dir: impl AsRef<Path>,
+    use_case: String,
+    workflow: Workflow,
     result: FullValue,
 ) -> Result<(), Error> {
     let api_endpoint: &str = api_endpoint.as_ref();
@@ -390,7 +305,7 @@ pub async fn process_instance(
                     Some(access) => access.clone(),
                     None => {
                         // Attempt to download it instead
-                        match data::download_data(api_endpoint, proxy_addr, certs_dir, data_dir, &name, &info.access).await {
+                        match data::download_data(api_endpoint, proxy_addr, certs_dir, data_dir, use_case, &name, workflow, &info.access).await {
                             Ok(Some(access)) => access,
                             Ok(None) => {
                                 return Err(Error::UnavailableDataset { name: name.into(), locs: info.access.keys().cloned().collect() });
@@ -413,7 +328,7 @@ pub async fn process_instance(
         }
     }
 
-    // DOne
+    // Done
     Ok(())
 }
 
@@ -699,7 +614,9 @@ pub async fn run_dummy_vm(state: &mut DummyVmState, what: impl AsRef<str>, snipp
     let snippet: &str = snippet.as_ref();
 
     // Compile the workflow
-    let workflow: Workflow = compile(&mut state.state, &mut state.source, &state.pindex, &state.dindex, None, &state.options, what, snippet)?;
+    let workflow: Workflow =
+        Workflow::from_source(&mut state.state, &mut state.source, &state.pindex, &state.dindex, None, &state.options, what, snippet)
+            .map_err(|err| Error::CompileError(err))?;
 
     // Run it in the local VM (which is a bit ugly do to the need to consume the VM itself)
     let res: (DummyVm, Result<FullValue, DummyVmError>) = state.vm.take().unwrap().exec(workflow).await;
@@ -722,28 +639,22 @@ pub async fn run_dummy_vm(state: &mut DummyVmState, what: impl AsRef<str>, snipp
 /// # Arguments
 /// - `state`: The OfflineVmState that we use to run the local VM.
 /// - `what`: The thing we're running. Either a filename, or something like stdin.
-/// - `snippet`: The snippet (as raw text) to compile and run.
+/// - `snippet`: The snippet to compile and run.
 ///
 /// # Returns
 /// The FullValue that the workflow returned, if any. If there was no value, returns FullValue::Void instead.
 ///
 /// # Errors
 /// This function errors if we failed to compile or run the workflow somehow.
-pub async fn run_offline_vm(state: &mut OfflineVmState, what: impl AsRef<str>, snippet: impl AsRef<str>) -> Result<FullValue, Error> {
-    let what: &str = what.as_ref();
-    let snippet: &str = snippet.as_ref();
-
-    // Compile the workflow
-    let workflow: Workflow = compile(&mut state.state, &mut state.source, &state.pindex, &state.dindex, None, &state.options, what, snippet)?;
-
+pub async fn run_offline_vm(state: &mut OfflineVmState, snippet: Snippet) -> Result<FullValue, Error> {
     // Run it in the local VM (which is a bit ugly do to the need to consume the VM itself)
-    let res: (OfflineVm, Result<FullValue, OfflineVmError>) = state.vm.take().unwrap().exec(workflow).await;
+    let res: (OfflineVm, Result<FullValue, OfflineVmError>) = state.vm.take().unwrap().exec(snippet.snippet).await;
     state.vm = Some(res.0);
     let res: FullValue = match res.1 {
         Ok(res) => res,
         Err(err) => {
             error!("{}", err);
-            state.state.offset += 1 + snippet.chars().filter(|c| *c == '\n').count();
+            state.state.offset += 1 + snippet.lines;
             return Err(Error::ExecError { err: Box::new(err) });
         },
     };
@@ -770,20 +681,11 @@ pub async fn run_offline_vm(state: &mut OfflineVmState, what: impl AsRef<str>, s
 pub async fn run_instance_vm(
     drv_endpoint: impl AsRef<str>,
     state: &mut InstanceVmState<Stdout, Stderr>,
-    what: impl AsRef<str>,
-    snippet: impl AsRef<str>,
+    snippet: &Snippet,
     profile: bool,
 ) -> Result<FullValue, Error> {
-    // Compile the workflow
-    let workflow: Workflow = {
-        // Acquire the locks
-        let pindex: MutexGuard<PackageIndex> = state.pindex.lock();
-        let dindex: MutexGuard<DataIndex> = state.dindex.lock();
-        compile(&mut state.state, &mut state.source, &pindex, &dindex, state.user.as_deref(), &state.options, what, snippet)?
-    };
-
     // Run the thing using the other function
-    run_instance(drv_endpoint, state, &workflow, profile).await
+    run_instance(drv_endpoint, state, &snippet.snippet, profile).await
 }
 
 
@@ -902,30 +804,21 @@ pub fn process_offline_result(result: FullValue) -> Result<(), Error> {
 ///
 /// # Errors
 /// This function may error if the given result was a dataset and we failed to retrieve it.
-pub async fn process_instance_result(api_endpoint: impl AsRef<str>, proxy_addr: &Option<String>, result: FullValue) -> Result<(), Error> {
-    let api_endpoint: &str = api_endpoint.as_ref();
+pub async fn process_instance_result(
+    api_endpoint: impl AsRef<str>,
+    proxy_addr: &Option<String>,
+    use_case: String,
+    workflow: Workflow,
+    result: FullValue,
+) -> Result<(), Error> {
+    let instance_name = InstanceInfo::get_active_name().map_err(|err| Error::ActiveInstanceReadError { err })?;
+    let certs_dir =
+        InstanceInfo::get_instance_path(&instance_name).map_err(|err| Error::InstancePathError { name: instance_name, err })?.join("certs");
 
-    // Fetch the certificae & data directories
-    let certs_dir: PathBuf = match InstanceInfo::get_active_name() {
-        Ok(name) => match InstanceInfo::get_instance_path(&name) {
-            Ok(path) => path.join("certs"),
-            Err(err) => {
-                return Err(Error::InstancePathError { name, err });
-            },
-        },
-        Err(err) => {
-            return Err(Error::ActiveInstanceReadError { err });
-        },
-    };
-    let datasets_dir: PathBuf = match ensure_datasets_dir(true) {
-        Ok(datas_dir) => datas_dir,
-        Err(err) => {
-            return Err(Error::DatasetsDirError { err });
-        },
-    };
+    let datasets_dir = ensure_datasets_dir(true).map_err(|err| Error::DatasetsDirError { err })?;
 
     // Run the instance function
-    process_instance(api_endpoint, proxy_addr, certs_dir, datasets_dir, result).await
+    process_instance(api_endpoint, proxy_addr, certs_dir, datasets_dir, use_case, workflow, result).await
 }
 
 
@@ -933,7 +826,7 @@ pub async fn process_instance_result(api_endpoint: impl AsRef<str>, proxy_addr: 
 
 
 /***** LIBRARY *****/
-/// Runs the given file with the given, optional data folder to resolve data declarations in.
+/// Runs the given workflow file with the given, optional data folder to resolve data declarations in.
 ///
 /// # Arguments
 /// - `certs_dir`: The directory with certificates proving our identity.
@@ -941,7 +834,7 @@ pub async fn process_instance_result(api_endpoint: impl AsRef<str>, proxy_addr: 
 /// - `dummy`: If given, uses a Dummy VM as backend instead of actually running any jobs.
 /// - `remote`: Whether to run on an remote Brane instance instead.
 /// - `language`: The language with which to compile the file.
-/// - `file`: The file to read and run. Can also be '-', in which case it is read from stdin instead.
+/// - `file`: The workflow file to read and run. Can also be '-', in which case it is read from stdin instead.
 /// - `profile`: If given, prints the profile timings to stdout if available.
 /// - `docker_opts`: The options with which we connect to the local Docker daemon.
 /// - `keep_containers`: Whether to keep containers after execution or not.
@@ -952,6 +845,7 @@ pub async fn process_instance_result(api_endpoint: impl AsRef<str>, proxy_addr: 
 pub async fn handle(
     proxy_addr: Option<String>,
     language: Language,
+    use_case: String,
     file: PathBuf,
     dummy: bool,
     remote: bool,
@@ -960,7 +854,7 @@ pub async fn handle(
     keep_containers: bool,
 ) -> Result<(), Error> {
     // Either read the file or read stdin
-    let (what, source_code): (Cow<str>, String) = if file == PathBuf::from("-") {
+    let (source, source_code): (Cow<str>, String) = if file == PathBuf::from("-") {
         let mut result: String = String::new();
         if let Err(err) = std::io::stdin().read_to_string(&mut result) {
             return Err(Error::StdinReadError { err });
@@ -990,12 +884,12 @@ pub async fn handle(
             };
 
             // Run the thing
-            remote_run(info, proxy_addr, options, what, source_code, profile).await
+            remote_run(info, use_case, proxy_addr, options, source, source_code, profile).await
         } else {
-            local_run(options, docker_opts, what, source_code, keep_containers).await
+            local_run(options, docker_opts, source, source_code, keep_containers).await
         }
     } else {
-        dummy_run(options, what, source_code).await
+        dummy_run(options, source, source_code).await
     }
 }
 
@@ -1048,8 +942,16 @@ async fn local_run(
 
     // First we initialize the remote thing
     let mut state: OfflineVmState = initialize_offline_vm(parse_opts, docker_opts, keep_containers)?;
+
+    // Compile the workflow
+    let workflow = Workflow::from_source(&mut state.state, &mut state.source, &state.pindex, &state.dindex, None, &state.options, what, source)
+        .map_err(|err| Error::CompileError(err))?;
+
+    let snippet = Snippet { lines: source.lines().count(), snippet: workflow };
+
     // Next, we run the VM (one snippet only ayway)
-    let res: FullValue = run_offline_vm(&mut state, what, source).await?;
+    let res: FullValue = run_offline_vm(&mut state, snippet).await?;
+
     // Then, we collect and process the result
     process_offline_result(res)?;
 
@@ -1063,32 +965,50 @@ async fn local_run(
 /// - `info`: Information about the remote instance, including as who we're logged-in.
 /// - `proxy_addr`: The address to proxy any data transfers through if they occur.
 /// - `options`: The ParseOptions that specify how to parse the incoming source.
-/// - `what`: A description of the source we're reading (e.g., the filename or stdin)
-/// - `source`: The source code to read.
+/// - `source`: A description of the source we're reading (e.g., the filename or stdin)
+/// - `workflow_content`: The source code to read.
 /// - `profile`: If given, prints the profile timings to stdout if reported by the remote.
 ///
 /// # Returns
 /// Nothing, but does print results and such to stdout. Might also produce new datasets.
 async fn remote_run(
     info: InstanceInfo,
+    use_case: String,
     proxy_addr: Option<String>,
     options: ParserOptions,
-    what: impl AsRef<str>,
     source: impl AsRef<str>,
+    workflow_content: impl AsRef<str>,
     profile: bool,
 ) -> Result<(), Error> {
     let api_endpoint: String = info.api.to_string();
     let drv_endpoint: String = info.drv.to_string();
-    let what: &str = what.as_ref();
     let source: &str = source.as_ref();
+    let workflow_content: &str = workflow_content.as_ref();
+    println!("Gonna do stuff");
 
     // First we initialize the remote thing
     let mut state: InstanceVmState<Stdout, Stderr> =
         initialize_instance_vm(&api_endpoint, &drv_endpoint, Some(info.user.clone()), None, options).await?;
+
+    // Compile the workflow
+    let workflow: Workflow = {
+        // Acquire the locks
+        let pindex: MutexGuard<PackageIndex> = state.pindex.lock();
+        let dindex: MutexGuard<DataIndex> = state.dindex.lock();
+        Workflow::from_source(&mut state.state, &mut state.source, &pindex, &dindex, state.user.as_deref(), &state.options, source, workflow_content)
+            .map_err(|err| Error::CompileError(err))?
+    };
+
+    println!("workflow-content: {:?}", workflow_content);
+    println!("workflow: {:#?}", workflow);
+
+    let snippet = Snippet { lines: source.lines().count(), snippet: workflow.clone() };
+
     // Next, we run the VM (one snippet only ayway)
-    let res: FullValue = run_instance_vm(drv_endpoint, &mut state, what, source, profile).await?;
+    let res: FullValue = run_instance_vm(drv_endpoint, &mut state, &snippet, profile).await?;
+
     // Then, we collect and process the result
-    process_instance_result(api_endpoint, &proxy_addr, res).await?;
+    process_instance_result(api_endpoint, &proxy_addr, use_case, workflow, res).await?;
 
     // Done
     Ok(())

--- a/brane-cli/src/test.rs
+++ b/brane-cli/src/test.rs
@@ -15,7 +15,8 @@
 use std::fs;
 use std::path::PathBuf;
 
-use brane_ast::ParserOptions;
+use brane_ast::ast::Snippet;
+use brane_ast::{ParserOptions, Workflow};
 use brane_exe::FullValue;
 use brane_tsk::docker::DockerOptions;
 use brane_tsk::input::prompt_for_input;
@@ -25,7 +26,7 @@ use specifications::package::PackageInfo;
 use specifications::version::Version;
 
 use crate::errors::TestError;
-use crate::run::{OfflineVmState, initialize_offline_vm, run_offline_vm};
+use crate::run::{self, initialize_offline_vm, run_offline_vm, OfflineVmState};
 use crate::utils::{ensure_datasets_dir, ensure_package_dir};
 
 
@@ -164,7 +165,7 @@ pub async fn test_generic(
     };
 
     // Build a phony workflow with that
-    let workflow: String = format!(
+    let workflow_content: String = format!(
         "import {}[{}]; return {}({});",
         info.name,
         info.version,
@@ -187,7 +188,17 @@ pub async fn test_generic(
             return Err(TestError::InitializeError { err });
         },
     };
-    let result: FullValue = match run_offline_vm(&mut state, "<test task>", workflow).await {
+
+    // Compile the workflow
+    let workflow = Workflow::from_source(&mut state.state, &mut state.source, &state.pindex, &state.dindex, None, &state.options, "<test task>", workflow_content.clone())
+        .map_err(|err| TestError::RunError { err: run::Error::CompileError(err) })?;
+
+    let snippet = Snippet {
+        lines: workflow_content.lines().count(),
+        snippet: workflow,
+    };
+
+    let result: FullValue = match run_offline_vm(&mut state, snippet).await {
         Ok(result) => result,
         Err(err) => {
             return Err(TestError::RunError { err });

--- a/brane-reg/src/data.rs
+++ b/brane-reg/src/data.rs
@@ -123,9 +123,9 @@ pub async fn assert_asset_permission(
         // Assert that they match with the request
         if client_name != at {
             return Err(AuthorizeError::AuthorizationUserMismatch {
-                who: format!("task {pc} executor"),
+                who: at.clone(),
                 authenticated: client_name.into(),
-                workflow: at.clone(),
+                workflow: workflow.clone(),
             });
         }
         if !input.contains_key(&data_name) {
@@ -133,13 +133,13 @@ pub async fn assert_asset_permission(
         }
     } else {
         // Authenticate the scientist
-        match &*workflow.user {
+        match workflow.user.as_ref() {
             Some(user) => {
                 if client_name != user {
                     return Err(AuthorizeError::AuthorizationUserMismatch {
-                        who: "end user".into(),
+                        who: user.to_string(),
                         authenticated: client_name.into(),
-                        workflow: user.clone(),
+                        workflow: workflow.clone(),
                     });
                 }
             },

--- a/brane-reg/src/store.rs
+++ b/brane-reg/src/store.rs
@@ -152,6 +152,7 @@ impl Store {
                     }
 
                     // Load it
+                    // FIXME: The store should not fail if a single dataset is not parsible
                     let info: AssetInfo = match AssetInfo::from_path(&info_path) {
                         Ok(info) => info,
                         Err(err) => {

--- a/brane-tsk/src/errors.rs
+++ b/brane-tsk/src/errors.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use bollard::ClientVersion;
 use brane_ast::func_id::FunctionId;
 use brane_ast::locations::{Location, Locations};
+use brane_ast::Workflow;
 use brane_exe::pc::ProgramCounter;
 use brane_shr::formatters::{BlockFormatter, Capitalizeable};
 use enum_debug::EnumDebug as _;
@@ -699,7 +700,7 @@ pub enum AuthorizeError {
     /// The data to authorize is not input to the task given as context.
     AuthorizationDataMismatch { pc: ProgramCounter, data_name: DataName },
     /// The user to authorize does not execute the given task.
-    AuthorizationUserMismatch { who: String, authenticated: String, workflow: String },
+    AuthorizationUserMismatch { who: String, authenticated: String, workflow: Workflow },
     /// An edge was referenced to be executed which wasn't an [`Edge::Node`](brane_ast::ast::Edge).
     AuthorizationWrongEdge { pc: ProgramCounter, got: String },
     /// An edge index given was out-of-bounds for the given function.
@@ -740,10 +741,10 @@ impl Display for AuthorizeError {
             AuthorizationUserMismatch { who, authenticated, workflow } => {
                 write!(
                     f,
-                    "Authorized user '{}' does not match {} user in workflow\n\nWorkflow:\n{}\n",
+                    "Authorized user '{}' does not match '{}' user in workflow\n\nWorkflow:\n{:#?}\n",
                     authenticated,
                     who,
-                    BlockFormatter::new(workflow)
+                    workflow
                 )
             },
             AuthorizationWrongEdge { pc, got } => write!(f, "Edge {pc} in workflow is not an Edge::Node but an Edge::{got}"),

--- a/specifications/src/registering.rs
+++ b/specifications/src/registering.rs
@@ -23,10 +23,12 @@ use serde_json::Value;
 pub struct DownloadAssetRequest {
     /// The use-case for which we're checking (determines which API registry to use).
     pub use_case: String,
+
     /// The workflow that we're checking.
     ///
     /// Note that we leave it open, as this would require importing `brane-ast` (and that would be a cycling dependency).
     pub workflow: Value,
+
     /// The task within the workflow that acts as the context in which the download occurs. If omitted, then it should be interpreted as the data being accessed to download the final result of the workflow.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task:     Option<(Option<u64>, u64)>,


### PR DESCRIPTION
Okay this started out as providing the `DownloadAssetRequest` to the download_data api in cli, but this cascaded into a whole refactor lead by the type system. Marking this PR as draft as I have no real way of testing this right now, nor the time to do so. However, without this PR we cannot really have any workflow return a result to the cli without crashing.

This also disables some functionality explicity in as specified in #195

Things still left to do:

- [ ] Update relevant documentation
- [ ] Test
- [ ] Fix broken endpoints & re-enable
